### PR TITLE
docs(backlog): revision PO — 21 correcciones + epicas 12-13 + replan 8 sprints

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1326,7 +1326,13 @@ Cada HU sigue el formato estándar de Scrum:
 | 9 — Perfil de usuario | 2 | 0 | 2 | 0 |
 | 10 — Reportes | 3 | 0 | 0 | 3 |
 | 11 — Deuda técnica | 3 | 2 | 1 | 0 |
-| **Total** | **45** | **27** | **14** | **4** |
+| 12 — Integración Wompi | 6 | 0 | 4 | 2 |
+| 13 — DevOps e Infraestructura | 6 | 1 | 1 | 4 |
+| 14 — Roadmap Fase 2 (post-MVP) | 8 | 0 | 0 | 8 |
+| Cross-cutting (MX-051..068) | 8 | 1 | 4 | 3 |
+| **Total MVP** | **65** | **29** | **23** | **13** |
+| **Total Fase 2** | **8** | **0** | **0** | **8** |
+| **Total general** | **73** | **29** | **23** | **21** |
 
 ### Por responsable
 
@@ -1363,20 +1369,22 @@ Capacity bruta no es lo mismo que capacity efectiva. La capacity real se ajusta 
 
 ---
 
-### Sprint 1 — Fundamentos de codigo (FIJO, no requiere poker)
+### Sprint 1 — Bloqueantes absolutos (FIJO, no requiere poker para asignacion)
 
-**Objetivo:** Base tecnica irrenunciable antes de que el equipo pueda construir features. Sin esto, cada PR puede romper el esquema de otro.
+**Objetivo:** Base tecnica irrenunciable. Sin estos 4 items NADA mas tiene sentido construir.
 
-**Por que va fijo sin planning poker:** Estas USs son must-have de fundacion. No pueden saltarse, no pueden esperar, no compiten con otras prioridades. Son criterio de entrada para que cualquier feature posterior tenga sentido.
+**Criterio de seleccion:** Items que bloquean estructuralmente todo lo demas. Sin estructura de paquetes, sin Flyway, sin BigDecimal y sin estructura hexagonal base, ninguna HU puede ejecutarse limpiamente.
 
-| ID | Historia | Responsable | Estimacion (pts) |
-|----|----------|-------------|-----------------|
-| EN-058 | Migrar esquema a Flyway | BD + Backend | A estimar en poker |
-| TT-068 | Refactorizar a arquitectura Hexagonal | Backend | A estimar en poker |
-| TT-005 | Corregir mapeo JPA (BigDecimal, JOINED, enums, indices) | BD + Backend | A estimar en poker |
-| TT-002 | Implementar DTOs para todas las entidades | Backend | A estimar en poker |
+| ID | Item | Tipo | Responsable | Estimacion (pts) |
+|----|------|------|-------------|-----------------|
+| EN-001 | Estructura de paquetes y convenciones | EN | Todos | A estimar en poker |
+| EN-058 | Migrar esquema a Flyway (eliminar ddl-auto=update) | EN | BD + Backend | A estimar en poker |
+| TT-005a | Migrar tipos monetarios a BigDecimal | TT | BD + Backend | A estimar en poker |
+| TT-068a | Estructura hexagonal base + bounded context Identidad | TT | Backend | A estimar en poker |
 
-**Nota:** Los puntos de estas USs igualmente se estiman en el planning poker para calibrar la escala del equipo y obtener una primera medicion de velocity al cierre del Sprint 1.
+**Nota:** Los puntos de estos items se estiman en el planning poker para calibrar escala del equipo y obtener primera medicion de velocity al cierre del Sprint 1. La asignacion (que items van) no se discute, solo los puntos.
+
+**Items "fundacionales blandos" candidatos a Sprint 2** (no fijados, asignar tras poker): TT-002 (DTOs), TT-004 (manejo errores RFC 7807), EN-003 (Spring Security setup), EN-006 (frontend scaffold), TT-005b (eliminar JOINED), TT-005c (enums + timestamps + indices), TT-068b (migrar Catalogo + Inventario).
 
 ---
 
@@ -1384,9 +1392,9 @@ Capacity bruta no es lo mismo que capacity efectiva. La capacity real se ajusta 
 
 **Listas separadas por prioridad MoSCoW.** Asignar a sprints despues del planning poker.
 
-#### Pool Must have (asignar primero)
+#### Pool Must have (asignar primero, ya excluye los 4 de Sprint 1)
 
-EN-001, EN-003, TT-004, EN-006, HU-007, HU-008, TT-009, TT-010, HU-011, HU-013, HU-014, HU-015, HU-016, HU-019, HU-020, HU-022, HU-023, TT-024, TT-025, HU-026, HU-027, HU-028, TT-029, HU-031, TT-043, TT-044, TT-045, HU-046, TT-047, EN-055, TT-067, EN-059.
+TT-002, EN-003, TT-004, TT-005b, TT-005c, EN-006, HU-007, HU-008, TT-009, TT-010, HU-011, HU-013, HU-014, HU-015, HU-016, HU-019, HU-020, HU-022, HU-023, TT-024, TT-025, HU-026, HU-027, HU-028, TT-029, HU-031, TT-043, TT-044, TT-045, HU-046, TT-047, EN-055, EN-059, TT-067, TT-068b, TT-068c.
 
 #### Pool Should have (asignar despues de cubrir Must)
 
@@ -1402,7 +1410,7 @@ HU-035, TT-048, HU-049, TT-050, MX-051, EN-056, EN-057, EN-060, HU-061, EN-064, 
 
 ### Preparacion (antes de la sesion)
 
-1. **Confirmar Sprint 1.** USs TT-002, TT-005, EN-058, TT-068 quedan en Sprint 1 sin discusion. Solo se estiman puntos.
+1. **Confirmar Sprint 1.** Items EN-001, EN-058, TT-005a, TT-068a quedan en Sprint 1 sin discusion. Solo se estiman puntos.
 2. **Acordar la escala de Fibonacci.** Convencion del equipo: 1, 2, 3, 5, 8, 13, 21. Mas de 21 = US demasiado grande, hay que partirla.
 3. **Definir referencia.** Elegir 1 US "ancla" que el equipo entienda completamente y asignarle un valor (ej. EN-001 = 3 pts). Todas las demas se comparan contra ella.
 4. **Tener BACKLOG.md a mano.** Cada miembro lee la US (descripcion + criterios de aceptacion) antes de votar.
@@ -1438,7 +1446,9 @@ HU-035, TT-048, HU-049, TT-050, MX-051, EN-056, EN-057, EN-060, HU-061, EN-064, 
 
 | Versión | Fecha | Autor | Cambio |
 |---------|-------|-------|--------|
-| 1.0 | Abril 2026 | K-Forge | Creación inicial del backlog |
+| 1.0 | Abril 2026 | K-Forge | Creacion inicial del backlog |
+| 1.1 | Mayo 2026 | Brian Vargas (PO) | Revision Ola 1: 21 correcciones criticas, epicas 12-13, items 046-068, replan 7→8 sprints, capacity real 60h |
+| 1.2 | Mayo 2026 | Brian Vargas (PO) | Revision Ola 2: reclasificacion completa (HU=34, TT=17, EN=12, MX=1), glosario de tipos al inicio, particion TT-068 → a/b/c y TT-005 → a/b/c por tamano, refinamiento beneficio HU-014/036, clarificacion TT-024/037/067, dependencias explicitas TT-029→TT-067, HU-030→liberacion reservas, epica 14 Roadmap Fase 2 con 8 items diferidos, Sprint 1 ajustado a 4 bloqueantes absolutos (EN-001, EN-058, TT-005a, TT-068a). |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -180,17 +180,17 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 ---
 
-#### US-006 — Configurar la estructura base del Frontend Angular
+#### US-006 — Configurar la estructura base del Frontend Angular (Atomic Design + Signals)
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como desarrollador Frontend, quiero estructurar el proyecto Angular con las carpetas, servicios base e interceptores HTTP necesarios, para tener una base sólida sobre la que construir todas las pantallas. |
+| **Historia** | Como desarrollador Frontend, quiero estructurar el proyecto Angular 21 con Atomic Design, Signals y PrimeNG, para tener una base solida, escalable y coherente con el design system de K-Forge. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🔴 Must Have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-072 |
-| **Criterios de aceptación** | - Existen las carpetas: `pages/`, `components/`, `services/`, `guards/`, `interceptors/`, `models/`. <br>- Hay un interceptor HTTP que agrega el token JWT a todas las peticiones. <br>- Hay un interceptor de errores que captura respuestas 401 y 403. <br>- Las rutas base están configuradas en `app.routes.ts`. <br>- Existe un ambiente (`environment.ts`) con la URL base de la API. |
-| **Notas** | Actualmente `app.routes.ts` está vacío y no hay ninguna estructura de carpetas definida. |
+| **Criterios de aceptación** | - Estructura de carpetas Atomic Design: `atoms/`, `molecules/`, `organisms/`, `templates/`, `pages/`. <br>- Patron Container/Presentational: los containers viven en `pages/`, los presentacionales en `organisms/` y `molecules/`. <br>- `AuthService` con Signal store de sesion (sin NgRx). <br>- `authInterceptor` que inyecta el JWT en cada peticion, captura 401 e intenta refresh antes de fallar. <br>- `authGuard` y `roleGuard` para proteger rutas segun autenticacion y rol. <br>- PrimeNG instalado con tema custom que usa los design tokens de K-Forge (negro/amarillo en `_tokens.scss`). <br>- Lazy loading configurado por feature en `app.routes.ts`. <br>- `environment.ts` con la URL base de la API por ambiente. |
+| **Notas** | Signals reemplaza NgRx para el MVP (10% del codigo, misma reactividad). PrimeNG proporciona los componentes UI; los design tokens de K-Forge personalizan el tema sin reescribir componentes. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -128,7 +128,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-001 — Estructura de carpetas y convenciones del proyecto
+#### EN-001 — Estructura de carpetas y convenciones del proyecto
 
 | Campo | Detalle |
 |-------|---------|
@@ -142,7 +142,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-002 — Implementar DTOs para todas las entidades del Backend
+#### TT-002 — Implementar DTOs para todas las entidades del Backend
 
 | Campo | Detalle |
 |-------|---------|
@@ -156,7 +156,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-003 — Configurar Spring Security con JWT
+#### EN-003 — Configurar Spring Security con JWT
 
 | Campo | Detalle |
 |-------|---------|
@@ -170,7 +170,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-004 — Implementar manejo global de errores en el Backend
+#### TT-004 — Implementar manejo global de errores en el Backend
 
 | Campo | Detalle |
 |-------|---------|
@@ -184,7 +184,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-005 — Corregir mapeo JPA: tipos, herencia, enums, indices y timestamps
+#### TT-005 — Corregir mapeo JPA: tipos, herencia, enums, indices y timestamps
 
 | Campo | Detalle |
 |-------|---------|
@@ -198,7 +198,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-006 — Configurar la estructura base del Frontend Angular (Atomic Design + Signals)
+#### EN-006 — Configurar la estructura base del Frontend Angular (Atomic Design + Signals)
 
 | Campo | Detalle |
 |-------|---------|
@@ -220,7 +220,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-007 — Registro de nuevo cliente
+#### HU-007 — Registro de nuevo cliente
 
 | Campo | Detalle |
 |-------|---------|
@@ -234,7 +234,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-008 — Inicio de sesión
+#### HU-008 — Inicio de sesión
 
 | Campo | Detalle |
 |-------|---------|
@@ -248,7 +248,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-009 — Validación automática del token JWT
+#### TT-009 — Validación automática del token JWT
 
 | Campo | Detalle |
 |-------|---------|
@@ -262,7 +262,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-010 — Autorización por roles
+#### TT-010 — Autorización por roles
 
 | Campo | Detalle |
 |-------|---------|
@@ -276,7 +276,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-011 — Cierre de sesión
+#### HU-011 — Cierre de sesión
 
 | Campo | Detalle |
 |-------|---------|
@@ -290,7 +290,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-012 — Recuperación de contraseña
+#### HU-012 — Recuperación de contraseña
 
 | Campo | Detalle |
 |-------|---------|
@@ -310,7 +310,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-013 — Crear un producto
+#### HU-013 — Crear un producto
 
 | Campo | Detalle |
 |-------|---------|
@@ -320,11 +320,11 @@ Cada HU sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - El endpoint `POST /api/productos` solo es accesible por VENDEDOR y ADMINISTRADOR. <br>- El producto requiere: nombre, categoría (enum), precio unitario positivo. <br>- La imagen es una URL externa opcional. <br>- El nombre debe ser único dentro de la misma categoría. <br>- El formulario de Angular valida todos los campos antes de enviar. |
-| **Notas** | La entidad `Producto` actualmente no tiene campo `imagen`. Debe añadirse (ver US-044). |
+| **Notas** | La entidad `Producto` actualmente no tiene campo `imagen`. Debe añadirse (ver TT-044). |
 
 ---
 
-#### US-014 — Editar un producto existente
+#### HU-014 — Editar un producto existente
 
 | Campo | Detalle |
 |-------|---------|
@@ -338,7 +338,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-015 — Eliminar un producto
+#### HU-015 — Eliminar un producto
 
 | Campo | Detalle |
 |-------|---------|
@@ -352,7 +352,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-016 — Listar productos con paginación y filtros
+#### HU-016 — Listar productos con paginación y filtros
 
 | Campo | Detalle |
 |-------|---------|
@@ -372,7 +372,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-017 — Búsqueda de productos por nombre parcial
+#### HU-017 — Búsqueda de productos por nombre parcial
 
 | Campo | Detalle |
 |-------|---------|
@@ -386,7 +386,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-018 — Filtro de productos por rango de precio
+#### HU-018 — Filtro de productos por rango de precio
 
 | Campo | Detalle |
 |-------|---------|
@@ -400,7 +400,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-019 — Ver detalle de un producto
+#### HU-019 — Ver detalle de un producto
 
 | Campo | Detalle |
 |-------|---------|
@@ -422,7 +422,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-020 — Agregar un producto al carrito
+#### HU-020 — Agregar un producto al carrito
 
 | Campo | Detalle |
 |-------|---------|
@@ -436,7 +436,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-021 — Modificar la cantidad de un producto en el carrito
+#### HU-021 — Modificar la cantidad de un producto en el carrito
 
 | Campo | Detalle |
 |-------|---------|
@@ -450,7 +450,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-022 — Eliminar un producto del carrito
+#### HU-022 — Eliminar un producto del carrito
 
 | Campo | Detalle |
 |-------|---------|
@@ -464,7 +464,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-023 — Ver el carrito con totales calculados
+#### HU-023 — Ver el carrito con totales calculados
 
 | Campo | Detalle |
 |-------|---------|
@@ -478,7 +478,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-024 — Validación de stock en tiempo real
+#### TT-024 — Validación de stock en tiempo real
 
 | Campo | Detalle |
 |-------|---------|
@@ -492,7 +492,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-025 — Máquina de estados del carrito
+#### TT-025 — Máquina de estados del carrito
 
 | Campo | Detalle |
 |-------|---------|
@@ -512,7 +512,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-026 — Iniciar el proceso de checkout
+#### HU-026 — Iniciar el proceso de checkout
 
 | Campo | Detalle |
 |-------|---------|
@@ -526,7 +526,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-027 — Seleccionar método de pago
+#### HU-027 — Seleccionar método de pago
 
 | Campo | Detalle |
 |-------|---------|
@@ -540,7 +540,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-028 — Generar factura al confirmar el pago
+#### HU-028 — Generar factura al confirmar el pago
 
 | Campo | Detalle |
 |-------|---------|
@@ -550,11 +550,11 @@ Cada HU sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Se crea un registro en `Factura` con: fecha, subtotal, IVA (19%), total, método de pago, referencia al cliente, al empleado/sistema y al carrito. <br>- Se crean registros en `DetalleFactura` con el precio y cantidad de cada producto al momento de la compra. <br>- El estado del carrito cambia a PAGO_EXITOSO. <br>- Todo ocurre en una sola transacción atómica (si algo falla, todo se revierte). |
-| **Notas** | Depende de US-043 (entidad `DetalleFactura`). |
+| **Notas** | Depende de TT-043 (entidad `DetalleFactura`). |
 
 ---
 
-#### US-029 — Descontar stock al facturar
+#### TT-029 — Descontar stock al facturar
 
 | Campo | Detalle |
 |-------|---------|
@@ -568,7 +568,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-030 — Cancelar el proceso de checkout
+#### HU-030 — Cancelar el proceso de checkout
 
 | Campo | Detalle |
 |-------|---------|
@@ -582,7 +582,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-031 — Ver historial de facturas
+#### HU-031 — Ver historial de facturas
 
 | Campo | Detalle |
 |-------|---------|
@@ -602,7 +602,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-032 — Registrar ingreso de stock
+#### HU-032 — Registrar ingreso de stock
 
 | Campo | Detalle |
 |-------|---------|
@@ -616,7 +616,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-033 — Ver inventario con alertas de stock bajo
+#### HU-033 — Ver inventario con alertas de stock bajo
 
 | Campo | Detalle |
 |-------|---------|
@@ -636,7 +636,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-034 — Listar usuarios con búsqueda y paginación
+#### HU-034 — Listar usuarios con búsqueda y paginación
 
 | Campo | Detalle |
 |-------|---------|
@@ -650,7 +650,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-035 — Crear cuenta de empleado
+#### HU-035 — Crear cuenta de empleado
 
 | Campo | Detalle |
 |-------|---------|
@@ -664,7 +664,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-036 — Editar datos de un usuario
+#### HU-036 — Editar datos de un usuario
 
 | Campo | Detalle |
 |-------|---------|
@@ -678,7 +678,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-037 — Eliminar o desactivar una cuenta de usuario
+#### HU-037 — Eliminar o desactivar una cuenta de usuario
 
 | Campo | Detalle |
 |-------|---------|
@@ -688,7 +688,7 @@ Cada HU sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-043 |
 | **Criterios de aceptación** | - **Usuario**: soft-delete con campo `deleted_at TIMESTAMP NULL`. Se anula la visibilidad pero se preserva el historial de facturas. El usuario no puede iniciar sesion una vez eliminado. <br>- **Producto**: soft-delete con `deleted_at`. Deja de aparecer en el catalogo pero las facturas existentes conservan la referencia. <br>- **Carrito**: hard-delete solo si esta vacio y tiene mas de 30 dias de abandono. Un carrito con items no se elimina fisicamente. <br>- Las entidades con soft-delete usan `@SQLDelete` + `@Where(clause = "deleted_at IS NULL")` en Hibernate para que las queries normales no retornen registros eliminados. <br>- El frontend muestra confirmacion antes de desactivar y aclara que el historial se preserva. |
-| **Notas** | El soft-delete tambien sirve como registro de auditoria basico: `deleted_at` indica cuando fue desactivado. Se complementa con `audit_log` (US-066) para tener el `deleted_by`. Ver ADR-0007. |
+| **Notas** | El soft-delete tambien sirve como registro de auditoria basico: `deleted_at` indica cuando fue desactivado. Se complementa con `audit_log` (TT-066) para tener el `deleted_by`. Ver ADR-0007. |
 
 ---
 
@@ -698,7 +698,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-038 — Ver y editar perfil propio
+#### HU-038 — Ver y editar perfil propio
 
 | Campo | Detalle |
 |-------|---------|
@@ -712,7 +712,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-039 — Cambiar contraseña
+#### HU-039 — Cambiar contraseña
 
 | Campo | Detalle |
 |-------|---------|
@@ -734,7 +734,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-040 — Reporte de ventas por período
+#### HU-040 — Reporte de ventas por período
 
 | Campo | Detalle |
 |-------|---------|
@@ -748,7 +748,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-041 — Ranking de productos más vendidos
+#### HU-041 — Ranking de productos más vendidos
 
 | Campo | Detalle |
 |-------|---------|
@@ -762,7 +762,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-042 — Dashboard de indicadores clave (KPIs)
+#### HU-042 — Dashboard de indicadores clave (KPIs)
 
 | Campo | Detalle |
 |-------|---------|
@@ -782,7 +782,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-043 — Crear la entidad JPA `DetalleFactura`
+#### TT-043 — Crear la entidad JPA `DetalleFactura`
 
 | Campo | Detalle |
 |-------|---------|
@@ -796,7 +796,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-044 — Agregar campo `imagen` a la entidad `Producto`
+#### TT-044 — Agregar campo `imagen` a la entidad `Producto`
 
 | Campo | Detalle |
 |-------|---------|
@@ -806,11 +806,11 @@ Cada HU sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - La entidad `Producto` tiene un campo `imagenUrl` de tipo `String`, opcional (nullable). <br>- El campo aparece en el DTO de respuesta de producto. <br>- La columna se agrega via migracion Flyway `V2__add_producto_imagen.sql` (NO via `ddl-auto=update`). |
-| **Notas** | `ddl-auto=update` debe estar deshabilitado tras US-058 (Flyway). Toda modificacion de schema usa migraciones Flyway versionadas. |
+| **Notas** | `ddl-auto=update` debe estar deshabilitado tras EN-058 (Flyway). Toda modificacion de schema usa migraciones Flyway versionadas. |
 
 ---
 
-#### US-045 — Alinear el enum `TipoDocumento` entre Java y PostgreSQL
+#### TT-045 — Alinear el enum `TipoDocumento` entre Java y PostgreSQL
 
 | Campo | Detalle |
 |-------|---------|
@@ -832,7 +832,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-046 — Iniciar un intento de pago con Wompi
+#### HU-046 — Iniciar un intento de pago con Wompi
 
 | Campo | Detalle |
 |-------|---------|
@@ -846,7 +846,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-047 — Recibir webhook de confirmacion de Wompi
+#### TT-047 — Recibir webhook de confirmacion de Wompi
 
 | Campo | Detalle |
 |-------|---------|
@@ -860,7 +860,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-048 — Reconciliar IntentoPago con la Factura
+#### TT-048 — Reconciliar IntentoPago con la Factura
 
 | Campo | Detalle |
 |-------|---------|
@@ -874,7 +874,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-049 — Manejar pagos rechazados o fallidos
+#### HU-049 — Manejar pagos rechazados o fallidos
 
 | Campo | Detalle |
 |-------|---------|
@@ -888,7 +888,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-050 — Capa anticorrupcion para Wompi (ACL)
+#### TT-050 — Capa anticorrupcion para Wompi (ACL)
 
 | Campo | Detalle |
 |-------|---------|
@@ -910,7 +910,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-055 — Dockerfiles para backend y frontend
+#### EN-055 — Dockerfiles para backend y frontend
 
 | Campo | Detalle |
 |-------|---------|
@@ -924,7 +924,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-056 — docker-compose para entorno local completo
+#### EN-056 — docker-compose para entorno local completo
 
 | Campo | Detalle |
 |-------|---------|
@@ -938,7 +938,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-057 — Pipeline CI/CD con GitHub Actions
+#### EN-057 — Pipeline CI/CD con GitHub Actions
 
 | Campo | Detalle |
 |-------|---------|
@@ -952,7 +952,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-058 — Migrar esquema a Flyway
+#### EN-058 — Migrar esquema a Flyway
 
 | Campo | Detalle |
 |-------|---------|
@@ -966,7 +966,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-059 — Perfiles de ambiente (local/dev/staging)
+#### EN-059 — Perfiles de ambiente (local/dev/staging)
 
 | Campo | Detalle |
 |-------|---------|
@@ -980,7 +980,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### US-060 — Despliegue en staging (Render/Railway)
+#### EN-060 — Despliegue en staging (Render/Railway)
 
 | Campo | Detalle |
 |-------|---------|
@@ -992,7 +992,7 @@ Cada HU sigue el formato estándar de Scrum:
 | **Criterios de aceptación** | - El backend esta desplegado en Render o Railway (free tier). <br>- La base de datos PostgreSQL esta provisionada en el mismo proveedor. <br>- La URL publica responde en `GET /actuator/health` con `{"status":"UP"}`. |
 | **Notas** | Sin backups. No es produccion real. |
 
-#### US-061 — Confirmacion de pago en pantalla del cliente
+#### HU-061 — Confirmacion de pago en pantalla del cliente
 
 | Campo | Detalle |
 |-------|---------|
@@ -1002,12 +1002,12 @@ Cada HU sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - Al volver de Wompi, el frontend consulta `GET /api/pagos/{id}` para obtener el estado del intento. <br>- Si APROBADO: pantalla de exito con resumen de factura y boton a historial. <br>- Si RECHAZADO: pantalla de error con motivo y boton de reintentar. <br>- La pantalla no depende solo de los parametros de URL (que pueden ser manipulados): siempre consulta el backend. |
-| **Notas** | El webhook (US-047) es el que realmente confirma el pago; esta US solo muestra el resultado al usuario. |
+| **Notas** | El webhook (TT-047) es el que realmente confirma el pago; esta US solo muestra el resultado al usuario. |
 
 ---
 
 
-#### US-051 — Captura basica de consentimiento al registro (educativo)
+#### MX-051 — Captura basica de consentimiento al registro (educativo)
 
 | Campo | Detalle |
 |-------|---------|
@@ -1022,7 +1022,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-062 — Observabilidad basica con Actuator
+#### EN-062 — Observabilidad basica con Actuator
 
 | Campo | Detalle |
 |-------|---------|
@@ -1037,7 +1037,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-063 — Documentacion de la API con OpenAPI y Swagger UI
+#### EN-063 — Documentacion de la API con OpenAPI y Swagger UI
 
 | Campo | Detalle |
 |-------|---------|
@@ -1052,7 +1052,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-064 — Rate limit en endpoints criticos con Bucket4j
+#### EN-064 — Rate limit en endpoints criticos con Bucket4j
 
 | Campo | Detalle |
 |-------|---------|
@@ -1067,7 +1067,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-065 — Notificaciones por correo al confirmar factura
+#### HU-065 — Notificaciones por correo al confirmar factura
 
 | Campo | Detalle |
 |-------|---------|
@@ -1082,7 +1082,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-066 — Auditoria de acciones criticas
+#### TT-066 — Auditoria de acciones criticas
 
 | Campo | Detalle |
 |-------|---------|
@@ -1097,7 +1097,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-067 — Reservas de stock durante el checkout
+#### TT-067 — Reservas de stock durante el checkout
 
 | Campo | Detalle |
 |-------|---------|
@@ -1112,7 +1112,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### US-068 — Refactorizar a arquitectura Hexagonal por bounded context
+#### TT-068 — Refactorizar a arquitectura Hexagonal por bounded context
 
 | Campo | Detalle |
 |-------|---------|
@@ -1188,10 +1188,10 @@ Capacity bruta no es lo mismo que capacity efectiva. La capacity real se ajusta 
 
 | ID | Historia | Responsable | Estimacion (pts) |
 |----|----------|-------------|-----------------|
-| US-058 | Migrar esquema a Flyway | BD + Backend | A estimar en poker |
-| US-068 | Refactorizar a arquitectura Hexagonal | Backend | A estimar en poker |
-| US-005 | Corregir mapeo JPA (BigDecimal, JOINED, enums, indices) | BD + Backend | A estimar en poker |
-| US-002 | Implementar DTOs para todas las entidades | Backend | A estimar en poker |
+| EN-058 | Migrar esquema a Flyway | BD + Backend | A estimar en poker |
+| TT-068 | Refactorizar a arquitectura Hexagonal | Backend | A estimar en poker |
+| TT-005 | Corregir mapeo JPA (BigDecimal, JOINED, enums, indices) | BD + Backend | A estimar en poker |
+| TT-002 | Implementar DTOs para todas las entidades | Backend | A estimar en poker |
 
 **Nota:** Los puntos de estas USs igualmente se estiman en el planning poker para calibrar la escala del equipo y obtener una primera medicion de velocity al cierre del Sprint 1.
 
@@ -1203,15 +1203,15 @@ Capacity bruta no es lo mismo que capacity efectiva. La capacity real se ajusta 
 
 #### Pool Must have (asignar primero)
 
-US-001, US-003, US-004, US-006, US-007, US-008, US-009, US-010, US-011, US-013, US-014, US-015, US-016, US-019, US-020, US-022, US-023, US-024, US-025, US-026, US-027, US-028, US-029, US-031, US-043, US-044, US-045, US-046, US-047, US-055, US-067, US-059.
+EN-001, EN-003, TT-004, EN-006, HU-007, HU-008, TT-009, TT-010, HU-011, HU-013, HU-014, HU-015, HU-016, HU-019, HU-020, HU-022, HU-023, TT-024, TT-025, HU-026, HU-027, HU-028, TT-029, HU-031, TT-043, TT-044, TT-045, HU-046, TT-047, EN-055, TT-067, EN-059.
 
 #### Pool Should have (asignar despues de cubrir Must)
 
-US-012, US-017, US-018, US-021, US-030, US-032, US-033, US-034, US-036, US-037, US-038, US-039, US-040, US-041, US-042, US-062, US-063.
+HU-012, HU-017, HU-018, HU-021, HU-030, HU-032, HU-033, HU-034, HU-036, HU-037, HU-038, HU-039, HU-040, HU-041, HU-042, EN-062, EN-063.
 
 #### Pool Could have (asignar segun capacidad)
 
-US-035, US-048, US-049, US-050, US-051, US-056, US-057, US-060, US-061, US-064, US-065, US-066.
+HU-035, TT-048, HU-049, TT-050, MX-051, EN-056, EN-057, EN-060, HU-061, EN-064, HU-065, TT-066.
 
 ---
 
@@ -1219,9 +1219,9 @@ US-035, US-048, US-049, US-050, US-051, US-056, US-057, US-060, US-061, US-064, 
 
 ### Preparacion (antes de la sesion)
 
-1. **Confirmar Sprint 1.** USs US-002, US-005, US-058, US-068 quedan en Sprint 1 sin discusion. Solo se estiman puntos.
+1. **Confirmar Sprint 1.** USs TT-002, TT-005, EN-058, TT-068 quedan en Sprint 1 sin discusion. Solo se estiman puntos.
 2. **Acordar la escala de Fibonacci.** Convencion del equipo: 1, 2, 3, 5, 8, 13, 21. Mas de 21 = US demasiado grande, hay que partirla.
-3. **Definir referencia.** Elegir 1 US "ancla" que el equipo entienda completamente y asignarle un valor (ej. US-001 = 3 pts). Todas las demas se comparan contra ella.
+3. **Definir referencia.** Elegir 1 US "ancla" que el equipo entienda completamente y asignarle un valor (ej. EN-001 = 3 pts). Todas las demas se comparan contra ella.
 4. **Tener BACKLOG.md a mano.** Cada miembro lee la US (descripcion + criterios de aceptacion) antes de votar.
 5. **Cada miembro vota en privado.** App de poker (Planning Poker Online, Scrum Poker, etc.) o cartas fisicas. Nada de "yo voto X" en voz alta primero — sesga al resto.
 
@@ -1237,7 +1237,7 @@ US-035, US-048, US-049, US-050, US-051, US-056, US-057, US-060, US-061, US-064, 
 ### Despues de la sesion — asignar a sprints
 
 1. **Calcular puntos por sprint** = capacity bruta (60 h) × factor de conversion. Sin velocity historica, asumir factor conservador: **30-40 pts/sprint** para Sprint 2 (primer sprint con USs ya estimadas).
-2. **Llenar Sprint 2** con USs Must have hasta llegar al limite de puntos. Respetar dependencias (US con `dep: US-XXX` requiere que la dependencia este en Sprint anterior o mismo).
+2. **Llenar Sprint 2** con items Must have hasta llegar al limite de puntos. Respetar dependencias (item con `dep: HU-XXX` o `dep: TT-XXX` requiere que la dependencia este en Sprint anterior o mismo).
 3. **Repetir para Sprints 3-8** con el resto del Pool Must have, luego Pool Should have, finalmente Pool Could have segun quepa.
 4. **Re-evaluar cada sprint.** Al cerrar Sprint N, calcular velocity real (pts completados / pts comprometidos). Ajustar capacity de Sprint N+1.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -532,7 +532,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Se crea un registro en `Factura` con: fecha, subtotal, IVA (19%), total, método de pago, referencia al cliente, al empleado/sistema y al carrito. <br>- Se crean registros en `DetalleFactura` con el precio y cantidad de cada producto al momento de la compra. <br>- El estado del carrito cambia a PAGO_EXITOSO. <br>- Todo ocurre en una sola transacción atómica (si algo falla, todo se revierte). |
-| **Notas** | Depende de US-044 (entidad `DetalleFactura`). |
+| **Notas** | Depende de US-043 (entidad `DetalleFactura`). |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1004,6 +1004,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-062 — Observabilidad basica con Actuator
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador, quiero que el backend exponga endpoints de salud y metricas, para poder monitorear el estado del sistema sin acceder directamente al servidor. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - `GET /actuator/health` retorna `{"status":"UP"}` cuando todo esta bien. <br>- `GET /actuator/info` retorna version y nombre del proyecto. <br>- Los logs se emiten en formato JSON (Logback) con nivel configurable por ambiente. <br>- Los endpoints de actuator estan protegidos y solo son accesibles con rol ADMINISTRADOR (excepto `/health`). |
+| **Notas** | Sin Grafana, Prometheus ni Loki para el MVP. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -664,13 +664,13 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como administrador, quiero eliminar o desactivar una cuenta de usuario que ya no la necesita, para mantener la base de datos limpia y ordenada. |
+| **Historia** | Como administrador, quiero desactivar o eliminar una cuenta de usuario que ya no la necesita, para mantener el sistema ordenado sin perder el historial de compras. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-043 |
-| **Criterios de aceptación** | - Si el usuario tiene facturas, no se puede eliminar y retorna 409. <br>- Si no tiene facturas, se elimina junto con sus registros de cliente/empleado y carritos no finalizados. <br>- El frontend pide confirmación antes de eliminar. |
-| **Notas** | Evaluar si implementar eliminación lógica (soft delete) o física. |
+| **Criterios de aceptación** | - **Usuario**: soft-delete con campo `deleted_at TIMESTAMP NULL`. Se anula la visibilidad pero se preserva el historial de facturas. El usuario no puede iniciar sesion una vez eliminado. <br>- **Producto**: soft-delete con `deleted_at`. Deja de aparecer en el catalogo pero las facturas existentes conservan la referencia. <br>- **Carrito**: hard-delete solo si esta vacio y tiene mas de 30 dias de abandono. Un carrito con items no se elimina fisicamente. <br>- Las entidades con soft-delete usan `@SQLDelete` + `@Where(clause = "deleted_at IS NULL")` en Hibernate para que las queries normales no retornen registros eliminados. <br>- El frontend muestra confirmacion antes de desactivar y aclara que el historial se preserva. |
+| **Notas** | El soft-delete tambien sirve como registro de auditoria basico: `deleted_at` indica cuando fue desactivado. Se complementa con `audit_log` (US-066) para tener el `deleted_by`. Ver ADR-0007. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -360,7 +360,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como empleado, quiero editar los datos de un producto existente, para corregir errores o actualizar el precio o la imagen. |
+| **Historia** | Como empleado, quiero editar los datos de un producto existente, para mantener el catalogo actualizado y preciso ante cambios de proveedor, ajustes de precio o renovacion de fotografia. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
 | **Estado** | 📋 Por hacer |
@@ -510,7 +510,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### TT-024 — Validación de stock en tiempo real
+#### TT-024 — Validación de stock al agregar item al carrito
 
 | Campo | Detalle |
 |-------|---------|
@@ -519,8 +519,8 @@ Cada HU sigue el formato estándar de Scrum:
 | **Prioridad** | 🔴 Must have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-024 |
-| **Criterios de aceptación** | - Si el stock es insuficiente, la operación se rechaza con 409 indicando la cantidad disponible. <br>- La validación ocurre tanto al agregar como al modificar la cantidad. |
-| **Notas** | — |
+| **Criterios de aceptación** | - Si el stock es insuficiente, la operación se rechaza con 409 indicando la cantidad disponible. <br>- La validación ocurre tanto al agregar como al modificar la cantidad. <br>- El calculo de disponible considera reservas activas: `disponible = cantidad - SUM(reservas activas)`. |
+| **Notas** | Acompañante de HU-020 (agregar producto al carrito). Diferente de TT-067: TT-024 es lectura (validacion sincrona), TT-067 es escritura (reserva pesimista durante checkout). |
 
 ---
 
@@ -595,8 +595,8 @@ Cada HU sigue el formato estándar de Scrum:
 | **Prioridad** | 🔴 Must have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-032 |
-| **Criterios de aceptación** | - El descuento de stock es parte de la misma transacción que genera la factura. <br>- Si el stock de algún producto es insuficiente en el momento exacto de facturar, toda la operación se revierte (rollback). <br>- El stock resultante nunca puede ser negativo. |
-| **Notas** | — |
+| **Criterios de aceptación** | - El descuento de stock es parte de la misma transacción que genera la factura. <br>- Si el stock de algún producto es insuficiente en el momento exacto de facturar, toda la operación se revierte (rollback). <br>- El stock resultante nunca puede ser negativo. <br>- **Depende de TT-067:** la confirmacion del pago consume la reserva existente (no decrementa stock real desde cero). |
+| **Notas** | Depende de TT-067 (reserva). El decremento real ocurre al consumir la reserva. |
 
 ---
 
@@ -609,8 +609,8 @@ Cada HU sigue el formato estándar de Scrum:
 | **Prioridad** | 🟡 Should have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-029 |
-| **Criterios de aceptación** | - Solo se puede cancelar si el carrito está en estado EN_PROCESO_DE_PAGO. <br>- Al cancelar, el estado vuelve a CON_PRODUCTOS. <br>- Los items del carrito permanecen intactos. |
-| **Notas** | — |
+| **Criterios de aceptación** | - Solo se puede cancelar si el carrito está en estado EN_PROCESO_DE_PAGO. <br>- Al cancelar, el estado vuelve a CON_PRODUCTOS. <br>- Los items del carrito permanecen intactos. <br>- **Las reservas de stock asociadas se liberan automaticamente,** restaurando el `disponible` del producto. |
+| **Notas** | Depende de TT-067 (reservas) — la cancelacion debe disparar la liberacion. |
 
 ---
 
@@ -700,7 +700,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como administrador, quiero editar los datos de cualquier usuario (nombre, apellido, teléfono, dirección, correo), para corregir información incorrecta. |
+| **Historia** | Como administrador, quiero editar los datos de cualquier usuario (nombre, apellido, teléfono, dirección, correo), para asegurar que los datos de contacto y facturacion del usuario sean precisos en todo momento. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
 | **Estado** | 📋 Por hacer |
@@ -710,7 +710,7 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### HU-037 — Eliminar o desactivar una cuenta de usuario
+#### HU-037 — Soft-delete de Usuario preservando historial
 
 | Campo | Detalle |
 |-------|---------|
@@ -1129,7 +1129,7 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### TT-067 — Reservas de stock durante el checkout
+#### TT-067 — Reserva pesimista de stock durante checkout (timeout 10min)
 
 | Campo | Detalle |
 |-------|---------|

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -67,10 +67,10 @@ El proyecto TiendaQ utilizará una arquitectura **monolítica** con una única b
 |-----------|--------|------------------------|
 | Product Owner | Brian Steven Vargas Clavijo | Definición de requerimientos y prioridades |
 | Scrum Master / Dev - Frontend | Juan Camilo Prieto Mestizo | Coordinación de sprints y retrospectivas |
-| Dev — BD | Nicoll Alejandra Duran Quintero | API REST, lógica de negocio, seguridad |
-| Dev — Backend | Miguel Angel Quintin Acero | Angular SPA, esquema PostgreSQL |
+| Dev — BD | Nicoll Alejandra Duran Quintero | Esquema PostgreSQL, modelo de datos, migraciones |
+| Dev — Backend | Miguel Angel Quintin Acero | API REST, lógica de negocio, seguridad |
 
-> **Nota:** En este backlog, "Frontend" hace referencia al desarrollador encargado de Angular, y "BD" hace referencia al desarrollador encargado del esquema de base de datos. Cuando una historia requiere coordinación entre ambos se indica explícitamente.
+> **Nota:** En este backlog, "Frontend" hace referencia al desarrollador encargado de Angular, "Backend" al desarrollador encargado de la API Spring Boot, y "BD" al desarrollador encargado del esquema PostgreSQL y las migraciones. Cuando una historia requiere coordinación se indica explícitamente.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1034,6 +1034,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-064 — Rate limit en endpoints criticos con Bucket4j
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como sistema, quiero limitar la cantidad de intentos en los endpoints de autenticacion y checkout, para prevenir ataques de fuerza bruta y abuso del servicio. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Limite de 5 intentos de login por IP en 15 minutos (retorna 429 al exceder). <br>- Limite de 3 registros por IP por hora. <br>- Limite de 10 inicios de checkout por IP por hora. <br>- El rate limit se implementa como filtro Spring (Bucket4j) en la cadena: `CorsFilter → RateLimitFilter → JwtAuthFilter`. |
+| **Notas** | Ver ADR del rate limit en `docs/adr/`. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1094,6 +1094,20 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-068 — Refactorizar a arquitectura Hexagonal por bounded context
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como equipo de desarrollo, quiero reorganizar los paquetes del backend siguiendo arquitectura Hexagonal por bounded context, para que cada contexto pueda evolucionar de forma independiente y la logica de dominio sea testeable sin Spring. |
+| **Responsable** | Backend |
+| **Prioridad** | 🔴 Must have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Los paquetes siguen la estructura: `com.tiendaq.<contexto>.domain`, `com.tiendaq.<contexto>.application`, `com.tiendaq.<contexto>.infrastructure`. <br>- Los 7 bounded contexts estan definidos: identidad, catalogo, inventario, carrito, pedidos, pagos, reportes. <br>- La logica de dominio no tiene dependencias de Spring (solo POJO/records). <br>- Los tests de dominio se ejecutan sin Spring Boot (`@SpringBootTest` solo para slices de integracion). |
+| **Notas** | Ver ADR-0001. Este refactor es prerrequisito para implementar use cases por contexto en Fase 2. |
+
+---
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1079,6 +1079,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-067 — Reservas de stock durante el checkout
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como sistema, quiero reservar el stock de los productos cuando un cliente inicia el checkout, para evitar que dos clientes compren el mismo articulo al mismo tiempo. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-032 |
+| **Criterios de aceptación** | - Al iniciar checkout, se crean registros en `stock_reservation(id, producto_id, carrito_id, cantidad, expires_at)`. <br>- El `expires_at` se fija a 10 minutos desde la creacion. <br>- Un job `@Scheduled` libera las reservas expiradas cada minuto. <br>- Al confirmar la factura, las reservas se convierten en descuento real de stock. <br>- Si no hay stock disponible (considerando reservas activas de otros carritos), el checkout retorna 409. |
+| **Notas** | Sin reservas hay race condition: dos clientes pueden confirmar el pago del mismo ultimo articulo. Ver ADR-0010. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1190,6 +1190,125 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
+### Épica 14 — Roadmap Fase 2 (post-MVP)
+
+**Descripción:** Items de producto y técnicos identificados durante el refinamiento pero que NO entran en el alcance del MVP académico. Quedan documentados como roadmap futuro para que el equipo los considere en una Fase 2.
+
+> **Tag:** Todos los items de esta épica llevan etiqueta `[Fase 2]`. Prioridad MoSCoW: 🟠 Could have. NO se asignan a sprints del MVP.
+
+---
+
+#### HU-069 — Actualizar registro de stock manualmente `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como empleado, quiero actualizar manualmente la cantidad de un registro de stock existente, para corregir errores de conteo o ajustes de inventario fisico. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-038 |
+| **Criterios de aceptación** | - El endpoint `PUT /api/inventario/stock/{id}` actualiza la cantidad. <br>- El cambio queda registrado en `audit_log` con motivo. <br>- Solo accesible para empleados. |
+| **Notas** | Diferido a Fase 2. El MVP solo permite ENTRADA via HU-032; correcciones manuales requieren intervencion en BD. |
+
+---
+
+#### HU-070 — Reporte de ventas por categoria `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como administrador, quiero ver un reporte de ventas agrupadas por categoria de producto, para identificar que segmentos generan mas ingresos. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-052 |
+| **Criterios de aceptación** | - Reporte con total vendido y cantidad de unidades por categoria. <br>- Filtros por rango de fechas. |
+| **Notas** | Diferido a Fase 2. HU-040 cubre ventas totales; HU-070 segmenta por categoria. |
+
+---
+
+#### HU-071 — Reporte de ventas por empleado `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como administrador, quiero ver un reporte de ventas atribuidas a cada empleado, para evaluar el desempeño individual. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-053 |
+| **Criterios de aceptación** | - Reporte con total vendido por empleado. <br>- Requiere asociar Factura a empleado responsable (no esta en el modelo MVP). |
+| **Notas** | Diferido a Fase 2. Requiere ampliar Factura con `empleado_id`. |
+
+---
+
+#### HU-072 — Exportar factura a PDF `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero descargar mi factura en formato PDF, para tener una copia fisica como soporte tributario. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Endpoint `GET /api/pedidos/facturas/{id}/pdf` retorna PDF. <br>- Plantilla con logo K-Forge, datos de cliente, detalle de productos, totales. |
+| **Notas** | Diferido a Fase 2. MVP solo muestra factura en pantalla. |
+
+---
+
+#### TT-073 — Auditoria de consultas a facturas `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como sistema, quiero registrar cada vez que un usuario consulta una factura, para tener trazabilidad completa de accesos a documentos fiscales. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Cada `GET /api/pedidos/facturas/{id}` registra una entrada en `audit_log`. <br>- Solo accesible al admin. |
+| **Notas** | Diferido a Fase 2. TT-066 cubre auditoria de mutaciones; TT-073 amplia a lecturas. |
+
+---
+
+#### HU-074 — Diseño responsivo del frontend `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como usuario en dispositivo movil, quiero que la interfaz se adapte al tamaño de mi pantalla, para usar la tienda comodamente desde el celular o tablet. |
+| **Responsable** | Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-070 |
+| **Criterios de aceptación** | - Breakpoints definidos para mobile (<768px), tablet (<1024px), desktop. <br>- Layout, menu y tablas se adaptan. <br>- Probado en Chrome devtools y dispositivos reales. |
+| **Notas** | Diferido a Fase 2. EN-006 entrega base desktop-first. |
+
+---
+
+#### HU-075 — Vaciar carrito de un solo paso `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero vaciar todo mi carrito con un solo clic, para empezar de cero rapidamente sin tener que eliminar items uno por uno. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-022 |
+| **Criterios de aceptación** | - Endpoint `DELETE /api/carrito/items` elimina todos los items del carrito activo. <br>- Frontend muestra confirmacion antes de vaciar. |
+| **Notas** | Diferido a Fase 2. MVP usa HU-022 (eliminar uno por uno). |
+
+---
+
+#### HU-076 — Busqueda combinada de productos `[Fase 2]`
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero buscar productos combinando multiples criterios simultaneos (nombre + categoria + rango de precio + disponibilidad), para encontrar exactamente lo que necesito en una sola consulta. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have `[Fase 2]` |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-016 |
+| **Criterios de aceptación** | - Endpoint acepta multiples filtros como query params. <br>- UI con formulario de busqueda avanzada. |
+| **Notas** | Diferido a Fase 2. MVP cubre busqueda por nombre (HU-017) y filtros independientes (HU-018, HU-016). |
+
+---
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1064,6 +1064,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-066 — Auditoria de acciones criticas
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como administrador, quiero que las acciones criticas (crear usuario, eliminar producto, generar factura) queden registradas en un log de auditoria, para poder rastrear quien hizo que y cuando. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Existe la tabla `audit_log(id, usuario_id, accion, entidad, entidad_id, antes, despues, fecha)`. <br>- Las acciones CREATE, UPDATE, DELETE en Usuario, Producto, Factura y StockEntry quedan registradas. <br>- El campo `antes` y `despues` guardan el estado en JSON. <br>- El registro es inmutable: no hay endpoint de eliminacion de audit_log. |
+| **Notas** | La auditoria no reemplaza a los logs del sistema; los complementa con contexto de negocio. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -267,8 +267,8 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Prioridad** | 🟡 Should have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-005 |
-| **Criterios de aceptación** | - Al hacer logout, el token queda invalidado. <br>- Peticiones posteriores con ese token retornan 401. <br>- El frontend elimina el token almacenado y redirige al login. |
-| **Notas** | — |
+| **Criterios de aceptación** | - El endpoint `POST /api/auth/logout` recibe el access token y el refresh token. <br>- El `jti` (JWT ID) del access token se registra en la tabla `revoked_token(jti, user_id, expires_at)`. <br>- El refresh token se marca como usado en la tabla `refresh_token`. <br>- Peticiones posteriores con ese access token retornan 401 (el filtro JWT verifica contra `revoked_token`). <br>- Un job `@Scheduled` limpia automaticamente los registros de `revoked_token` cuyo `expires_at` ya paso, para no crecer indefinidamente. <br>- El frontend elimina ambos tokens del almacenamiento local y redirige al login. |
+| **Notas** | El RNF-013 (stateless) y RF-005 (logout efectivo) son contradictorios si no existe la tabla de blacklist. La tabla `revoked_token` resuelve la contradiccion: el sistema es stateless por defecto pero invalida tokens explicitamente cuando es necesario. Ver ADR-0002. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1019,6 +1019,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-063 — Documentacion de la API con OpenAPI y Swagger UI
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador, quiero que la API este documentada automaticamente con OpenAPI, para que cualquier integrante pueda explorar y probar los endpoints sin necesidad de Postman. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RNF-020 |
+| **Criterios de aceptación** | - La dependencia `springdoc-openapi-starter-webmvc-ui` esta en el `pom.xml`. <br>- `GET /swagger-ui.html` muestra la UI de Swagger con todos los endpoints documentados. <br>- `GET /v3/api-docs` retorna el YAML de OpenAPI. <br>- El archivo `docs/api/openapi.yaml` esta commiteado y se actualiza con cada cambio de la API. |
+| **Notas** | El archivo commiteado es la fuente de verdad para generar colecciones de Postman. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -989,6 +989,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-051 — Captura basica de consentimiento al registro (educativo)
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como estudiante que aprende sobre Habeas Data, quiero implementar un checkbox de consentimiento al registrarse, para experimentar con los requisitos basicos de la Ley 1581/2012 en un contexto academico. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - El formulario de registro incluye un checkbox "Acepto la politica de privacidad" (obligatorio). <br>- El backend registra `consentimiento_fecha` y `consentimiento_ip` en el usuario. <br>- El endpoint de registro rechaza con 400 si el campo no es `true`. |
+| **Notas** | Solo educativo. El proyecto no saldra a produccion real. Las obligaciones formales completas de la ley (anonimizacion, exportacion) quedan fuera del alcance del MVP. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -93,10 +93,10 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 | Estado | Descripción |
 |--------|------------|
-| 📋 Ready | Aún no se ha iniciado |
-| 🔄 In progress | Alguien está trabajando en ella actualmente |
-| 👁️ In review | Terminada, esperando revisión del equipo |
-| ✅ Done | Completada y aceptada por el Product Owner |
+| 📋 Por hacer | Aún no se ha iniciado |
+| 🔄 En curso | Alguien está trabajando en ella actualmente |
+| 👁️ En revisión | Terminada, esperando revisión del equipo |
+| ✅ Hecho | Completada y aceptada por el Product Owner |
 
 ---
 
@@ -117,7 +117,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como equipo, quiero tener definidas las convenciones de código y la estructura de carpetas del proyecto, para que todos trabajemos de forma coherente sin pisarnos. |
 | **Responsable** | Todos (revisar AGENTS.md y la guia org-level CONTRIBUTING) |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Las convenciones de commits (Conventional Commits) están documentadas y todos las siguen. <br>- La estructura de ramas Git Flow está activa (`main`, `develop`, `feature/*`). <br>- El equipo acordó cómo nombrar branches, clases y métodos. |
 | **Notas** | La guia de contribucion vive en el repo org-level [`K-Forge/.github/blob/main/CONTRIBUTING.md`](https://github.com/K-Forge/.github/blob/main/CONTRIBUTING.md). El `AGENTS.md` local complementa con contexto especifico de TiendaQ. |
@@ -131,7 +131,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero crear DTOs (objetos de transferencia de datos) para cada entidad, para que la API nunca exponga directamente las entidades JPA ni datos sensibles como contraseñas. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RNF-019 |
 | **Criterios de aceptación** | - Existe un DTO de request y uno de response para cada entidad (Usuario, Producto, Carrito, etc.). <br>- Ningún endpoint retorna directamente una entidad JPA. <br>- El campo `contrasena` nunca aparece en ninguna respuesta de la API. |
 | **Notas** | Actualmente todos los controllers exponen entidades JPA directamente. Esto es un problema de seguridad crítico. |
@@ -145,7 +145,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero configurar Spring Security con autenticación JWT, para que todos los endpoints estén protegidos y solo los usuarios autorizados puedan acceder. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-002, RF-003, RF-004 |
 | **Criterios de aceptación** | - Existe un `SecurityFilterChain` configurado. <br>- Los endpoints públicos (login, registro) no requieren token. <br>- Los endpoints protegidos retornan 401 si no hay token válido. <br>- Los endpoints de administrador retornan 403 si el rol no es suficiente. |
 | **Notas** | La dependencia de Spring Security ya está en el `pom.xml`, pero sin configuración activa. |
@@ -159,7 +159,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero un manejador global de excepciones, para que todos los errores de la API tengan un formato JSON consistente y no expongan detalles internos del sistema. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-058, RF-059 |
 | **Criterios de aceptación** | - Existe una clase `@ControllerAdvice` que captura excepciones. <br>- Todos los errores retornan JSON con: `timestamp`, `status`, `error`, `message`, `path`. <br>- Ningún error expone stack traces ni nombres de tablas de la base de datos. |
 | **Notas** | El paquete `exception/` existe en el proyecto pero está vacío. |
@@ -173,7 +173,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero verificar que el esquema PostgreSQL esté perfectamente alineado con las entidades JPA, para evitar errores de mapeo al ejecutar la aplicación. |
 | **Responsable** | BD |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Los tipos ENUM en PostgreSQL coinciden exactamente con los enums de Java. <br>- Los nombres de columnas en SQL coinciden con los mapeados en `@Column`. <br>- El enum `TipoDocumento` en Java (que tiene NIT, RUT, OTRO) está alineado con el tipo PostgreSQL (que actualmente no los tiene). |
 | **Notas** | Inconsistencia detectada: `TipoDocumento` en Java tiene valores que no están en el ENUM de PostgreSQL. |
@@ -187,7 +187,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Frontend, quiero estructurar el proyecto Angular con las carpetas, servicios base e interceptores HTTP necesarios, para tener una base sólida sobre la que construir todas las pantallas. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-072 |
 | **Criterios de aceptación** | - Existen las carpetas: `pages/`, `components/`, `services/`, `guards/`, `interceptors/`, `models/`. <br>- Hay un interceptor HTTP que agrega el token JWT a todas las peticiones. <br>- Hay un interceptor de errores que captura respuestas 401 y 403. <br>- Las rutas base están configuradas en `app.routes.ts`. <br>- Existe un ambiente (`environment.ts`) con la URL base de la API. |
 | **Notas** | Actualmente `app.routes.ts` está vacío y no hay ninguna estructura de carpetas definida. |
@@ -209,7 +209,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario nuevo, quiero registrarme con mis datos personales (nombre, apellido, documento, teléfono, correo, dirección y contraseña), para crear mi cuenta y poder hacer compras. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-001 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/registro` crea un Usuario y un Cliente en una sola transacción. <br>- La contraseña se almacena con hash BCrypt (nunca en texto plano). <br>- Si el correo, documento o teléfono ya existen, retorna 409 con mensaje claro. <br>- El formulario de Angular valida los campos en tiempo real antes de enviar. <br>- La respuesta nunca incluye la contraseña. |
 | **Notas** | Actualmente la creación de usuario y cliente son operaciones separadas y las contraseñas no se hashean. |
@@ -223,7 +223,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario registrado, quiero iniciar sesión con mi correo y contraseña, para acceder al sistema con las funciones que corresponden a mi rol. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-002 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/login` retorna un token JWT válido al ingresar credenciales correctas. <br>- El token contiene el ID del usuario, su correo y su rol. <br>- Si las credenciales son incorrectas, retorna 401 con mensaje genérico (no indicar si el error es en el correo o en la contraseña, por seguridad). <br>- El frontend almacena el token de forma segura y redirige al usuario según su rol. |
 | **Notas** | —  |
@@ -237,7 +237,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero validar el token JWT en cada petición a un endpoint protegido, para garantizar que solo usuarios autenticados accedan a los recursos. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-003 |
 | **Criterios de aceptación** | - Las peticiones sin token retornan 401. <br>- Las peticiones con token expirado retornan 401. <br>- Las peticiones con token válido pero rol insuficiente retornan 403. <br>- Los tokens tienen una expiración configurable (por defecto 24 horas). |
 | **Notas** | — |
@@ -251,7 +251,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero restringir el acceso a cada endpoint según el rol del usuario autenticado, para que un cliente no pueda hacer lo que solo puede hacer un empleado o administrador. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-004 |
 | **Criterios de aceptación** | - Los endpoints de gestión de productos y stock solo son accesibles por VENDEDOR y ADMINISTRADOR. <br>- Los endpoints de gestión de usuarios solo son accesibles por ADMINISTRADOR. <br>- Los endpoints de carrito, perfil e historial son accesibles por CLIENTE. <br>- El rol ADMINISTRADOR hereda los permisos de VENDEDOR. |
 | **Notas** | — |
@@ -265,7 +265,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero poder cerrar sesión, para que mi sesión quede invalidada y nadie más pueda usarla desde el mismo dispositivo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-005 |
 | **Criterios de aceptación** | - Al hacer logout, el token queda invalidado. <br>- Peticiones posteriores con ese token retornan 401. <br>- El frontend elimina el token almacenado y redirige al login. |
 | **Notas** | — |
@@ -279,7 +279,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario, quiero recuperar mi contraseña si la olvidé, para poder volver a acceder sin necesitar al administrador. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-006 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/recuperar` acepta un correo y genera un token temporal. <br>- El token temporal se registra en consola o en un endpoint dedicado (no se envía correo real). <br>- Con el token temporal el usuario puede establecer una nueva contraseña hasheada. |
 | **Notas** | El envío real de correos está fuera del alcance del proyecto. |
@@ -299,7 +299,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero crear un producto con nombre, categoría, precio e imagen (URL), para que esté disponible en el catálogo de la tienda. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - El endpoint `POST /api/productos` solo es accesible por VENDEDOR y ADMINISTRADOR. <br>- El producto requiere: nombre, categoría (enum), precio unitario positivo. <br>- La imagen es una URL externa opcional. <br>- El nombre debe ser único dentro de la misma categoría. <br>- El formulario de Angular valida todos los campos antes de enviar. |
 | **Notas** | La entidad `Producto` actualmente no tiene campo `imagen`. Debe añadirse (ver US-044). |
@@ -313,7 +313,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero editar los datos de un producto existente, para corregir errores o actualizar el precio o la imagen. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-011 |
 | **Criterios de aceptación** | - El endpoint `PUT /api/productos/{id}` actualiza nombre, categoría, precio e imagen. <br>- Si el producto no existe, retorna 404. <br>- La validación de unicidad de nombre por categoría se mantiene al editar. |
 | **Notas** | — |
@@ -327,7 +327,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero eliminar un producto que no tiene stock ni compras asociadas, para mantener el catálogo limpio y actualizado. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-012 |
 | **Criterios de aceptación** | - Si el producto tiene stock o está en facturas, el endpoint retorna 409 con un mensaje descriptivo. <br>- Si se puede eliminar, retorna 204 (sin contenido). <br>- El frontend muestra un diálogo de confirmación antes de eliminar. |
 | **Notas** | — |
@@ -341,7 +341,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cualquier usuario, quiero ver la lista de productos con paginación, filtros por categoría y búsqueda por nombre, para encontrar lo que necesito sin ver todo el catálogo de golpe. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-010, RF-013 |
 | **Criterios de aceptación** | - El endpoint `GET /api/productos` soporta los parámetros: `page`, `size`, `sortBy`, `direction`. <br>- El endpoint `GET /api/productos/categoria/{categoria}` filtra por categoría. <br>- La respuesta incluye metadatos de paginación: `totalElements`, `totalPages`, `currentPage`. <br>- El frontend muestra los productos en una grilla con controles de paginación. |
 | **Notas** | Actualmente el endpoint no soporta paginación ni `Pageable`. |
@@ -361,7 +361,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero buscar productos escribiendo solo parte del nombre, para encontrar lo que busco sin tener que escribirlo completo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-014 |
 | **Criterios de aceptación** | - El endpoint acepta un parámetro `nombre` y hace búsqueda ILIKE (insensible a mayúsculas). <br>- Si no hay resultados, retorna lista vacía (no error). <br>- El parámetro debe tener al menos 2 caracteres. <br>- El frontend tiene un campo de búsqueda que se activa al escribir. |
 | **Notas** | Requiere agregar `findByNombreContainingIgnoreCase` al repositorio. |
@@ -375,7 +375,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero filtrar productos por rango de precio (mínimo y máximo), para ver solo los que puedo pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-015 |
 | **Criterios de aceptación** | - El endpoint acepta parámetros `precioMin` y `precioMax` (ambos opcionales). <br>- Si solo se proporciona `precioMin`, filtra productos con precio ≥ precioMin. <br>- Si solo se proporciona `precioMax`, filtra productos con precio ≤ precioMax. <br>- El frontend tiene controles de rango de precio. |
 | **Notas** | — |
@@ -389,7 +389,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver el detalle completo de un producto (nombre, categoría, precio, imagen y stock disponible), para decidir si lo compro. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-017 |
 | **Criterios de aceptación** | - La pantalla de detalle consume el endpoint `GET /api/productos/{id}`. <br>- Si el stock es 0, se muestra la etiqueta "Agotado". <br>- Hay un botón para agregar al carrito (deshabilitado si está agotado). <br>- La imagen se muestra si existe URL; si no, se muestra un placeholder. |
 | **Notas** | — |
@@ -411,7 +411,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero agregar un producto a mi carrito indicando la cantidad deseada, para ir seleccionando lo que quiero comprar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-019 |
 | **Criterios de aceptación** | - Si el cliente no tiene carrito activo, el sistema lo crea automáticamente con estado VACÍO. <br>- Si el producto ya está en el carrito, se suma la cantidad. <br>- Si el stock es insuficiente, retorna 409 con la cantidad disponible. <br>- El precio unitario se registra al momento de agregar (no cambia aunque el producto se actualice después). <br>- El estado del carrito cambia a CON_PRODUCTOS. |
 | **Notas** | — |
@@ -425,7 +425,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero cambiar la cantidad de un producto en mi carrito, para ajustar mi pedido antes de pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-020 |
 | **Criterios de aceptación** | - Si la nueva cantidad es válida, se actualiza el item. <br>- Si la cantidad es 0, el item se elimina. <br>- Si el carrito queda vacío, el estado cambia a VACÍO. <br>- El sistema valida que el stock sea suficiente para la nueva cantidad. |
 | **Notas** | — |
@@ -439,7 +439,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero eliminar un producto específico de mi carrito, para cambiar de opinión sobre ese artículo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-021 |
 | **Criterios de aceptación** | - El item se elimina del carrito. <br>- Si el carrito queda vacío, el estado cambia a VACÍO. <br>- El frontend muestra confirmación antes de eliminar. |
 | **Notas** | — |
@@ -453,7 +453,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver mi carrito con la lista de productos, el subtotal, el IVA (19%) y el total, para saber exactamente cuánto voy a pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-023 |
 | **Criterios de aceptación** | - La respuesta incluye: lista de items, subtotal, IVA (19% del subtotal), total. <br>- Si el cliente no tiene carrito activo, retorna estructura vacía (no error). <br>- El carrito es accesible desde cualquier pantalla (componente lateral o modal). |
 | **Notas** | — |
@@ -467,7 +467,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero validar el stock disponible cada vez que se agrega o modifica un item en el carrito, para no permitir vender más de lo que hay en inventario. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-024 |
 | **Criterios de aceptación** | - Si el stock es insuficiente, la operación se rechaza con 409 indicando la cantidad disponible. <br>- La validación ocurre tanto al agregar como al modificar la cantidad. |
 | **Notas** | — |
@@ -481,7 +481,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero que el carrito siga una máquina de estados definida, para que el flujo de compra sea coherente y no se pueda saltar pasos. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-025 |
 | **Criterios de aceptación** | - Las transiciones válidas son: VACÍO → CON_PRODUCTOS, CON_PRODUCTOS → VACÍO, CON_PRODUCTOS → EN_PROCESO_DE_PAGO, EN_PROCESO_DE_PAGO → PAGO_PENDIENTE, PAGO_PENDIENTE → PAGO_EXITOSO, EN_PROCESO_DE_PAGO → CON_PRODUCTOS. <br>- Cualquier otra transición retorna 400 con mensaje descriptivo. |
 | **Notas** | — |
@@ -501,7 +501,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero iniciar el proceso de pago desde mi carrito, para formalizar mi compra. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-026 |
 | **Criterios de aceptación** | - El sistema re-valida el stock de todos los productos del carrito al iniciar el checkout. <br>- Si hay stock insuficiente en algún producto, retorna 409 con el detalle. <br>- Si todo está bien, el estado del carrito cambia a EN_PROCESO_DE_PAGO. <br>- El frontend muestra un resumen del carrito antes de confirmar. |
 | **Notas** | — |
@@ -515,7 +515,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero seleccionar el método de pago que prefiero (PSE, tarjeta de crédito, tarjeta débito, efectivo o transferencia), para completar mi compra. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - Los métodos disponibles son los definidos en el enum `MetodoPago`. <br>- Al seleccionar, el estado del carrito cambia a PAGO_PENDIENTE. <br>- El método seleccionado queda registrado para la factura. |
 | **Notas** | No se realiza procesamiento real del pago. Solo se registra el método. |
@@ -529,7 +529,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero generar una factura completa con el detalle de los productos comprados cuando el cliente confirma el pago, para tener un registro permanente e inmutable de la transacción. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Se crea un registro en `Factura` con: fecha, subtotal, IVA (19%), total, método de pago, referencia al cliente, al empleado/sistema y al carrito. <br>- Se crean registros en `DetalleFactura` con el precio y cantidad de cada producto al momento de la compra. <br>- El estado del carrito cambia a PAGO_EXITOSO. <br>- Todo ocurre en una sola transacción atómica (si algo falla, todo se revierte). |
 | **Notas** | Depende de US-044 (entidad `DetalleFactura`). |
@@ -543,7 +543,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero descontar automáticamente el stock de cada producto vendido al generar la factura, para que el inventario siempre refleje la realidad. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-032 |
 | **Criterios de aceptación** | - El descuento de stock es parte de la misma transacción que genera la factura. <br>- Si el stock de algún producto es insuficiente en el momento exacto de facturar, toda la operación se revierte (rollback). <br>- El stock resultante nunca puede ser negativo. |
 | **Notas** | — |
@@ -557,7 +557,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero cancelar el proceso de pago si aún no lo he confirmado, para volver a mi carrito y seguir comprando o modificar mi pedido. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-029 |
 | **Criterios de aceptación** | - Solo se puede cancelar si el carrito está en estado EN_PROCESO_DE_PAGO. <br>- Al cancelar, el estado vuelve a CON_PRODUCTOS. <br>- Los items del carrito permanecen intactos. |
 | **Notas** | — |
@@ -571,7 +571,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver mi historial de compras con el detalle de cada factura, para llevar control de todo lo que he comprado. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-030, RF-031 |
 | **Criterios de aceptación** | - La lista está paginada y ordenada por fecha descendente (más reciente primero). <br>- Cada factura muestra: número, fecha, total y método de pago. <br>- Al hacer clic en una factura, se ve el detalle completo con productos, cantidades y precios. <br>- Un cliente solo puede ver sus propias facturas. |
 | **Notas** | — |
@@ -591,7 +591,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero registrar un ingreso de stock para un producto indicando la cantidad y la fecha, para actualizar el inventario cuando llegue mercancía. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-034 |
 | **Criterios de aceptación** | - El endpoint `POST /api/stock` crea un registro de stock asociado al producto. <br>- La cantidad debe ser un entero positivo. <br>- Si el producto no existe, retorna 404. <br>- El frontend tiene un formulario para ingresar la cantidad. |
 | **Notas** | — |
@@ -605,7 +605,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero ver el inventario general con una alerta visual para los productos con poco stock, para saber cuándo debo pedir más mercancía. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-036, RF-037 |
 | **Criterios de aceptación** | - Los productos con stock ≤ 5 unidades se marcan como "stock bajo". <br>- Existe un endpoint dedicado `GET /api/stock/bajo` que retorna solo los productos con stock bajo. <br>- El frontend muestra un indicador visual destacado (color rojo o etiqueta) para estos productos. |
 | **Notas** | El umbral de 5 unidades debe ser configurable en el futuro. |
@@ -625,7 +625,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver la lista de todos los usuarios del sistema con paginación y búsqueda por nombre, correo o documento, para tener control sobre quién tiene acceso. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-039, RF-045 |
 | **Criterios de aceptación** | - El endpoint retorna la lista paginada de usuarios sin incluir contraseñas. <br>- Se puede buscar por documento (exacto) o por correo (parcial). <br>- Se puede filtrar por tipo de usuario (REGISTRADO, SIN_REGISTRAR). |
 | **Notas** | — |
@@ -639,7 +639,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero crear cuentas de empleados (vendedor o administrador), para darles acceso al sistema con los permisos correspondientes. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-041 |
 | **Criterios de aceptación** | - Se crea el Usuario y el Empleado en una sola transacción. <br>- La contraseña se hashea con BCrypt. <br>- El tipo de empleado puede ser VENDEDOR o ADMINISTRADOR. |
 | **Notas** | — |
@@ -653,7 +653,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero editar los datos de cualquier usuario (nombre, apellido, teléfono, dirección, correo), para corregir información incorrecta. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-042 |
 | **Criterios de aceptación** | - No se puede modificar el tipo ni número de documento. <br>- Si se cambia el correo, se valida que no exista en otro usuario. <br>- Si se proporciona nueva contraseña, se hashea; si no, la existente no cambia. |
 | **Notas** | — |
@@ -667,7 +667,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero eliminar o desactivar una cuenta de usuario que ya no la necesita, para mantener la base de datos limpia y ordenada. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-043 |
 | **Criterios de aceptación** | - Si el usuario tiene facturas, no se puede eliminar y retorna 409. <br>- Si no tiene facturas, se elimina junto con sus registros de cliente/empleado y carritos no finalizados. <br>- El frontend pide confirmación antes de eliminar. |
 | **Notas** | Evaluar si implementar eliminación lógica (soft delete) o física. |
@@ -687,7 +687,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero ver mi información de perfil y poder editar mi teléfono y dirección, para mantener mis datos de contacto actualizados. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-046, RF-047 |
 | **Criterios de aceptación** | - El endpoint `GET /api/perfil` retorna los datos del usuario autenticado sin incluir la contraseña. <br>- Solo se pueden editar: teléfono y dirección (no nombre, apellido ni documento). <br>- El cambio de correo requiere verificar la contraseña actual. |
 | **Notas** | — |
@@ -701,7 +701,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero cambiar mi contraseña verificando la actual, para mantener mi cuenta segura. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-048 |
 | **Criterios de aceptación** | - El usuario debe proveer la contraseña actual (verificación con BCrypt). <br>- La nueva contraseña debe tener mínimo 8 caracteres, una mayúscula y un número. <br>- La nueva contraseña se almacena hasheada con BCrypt. |
 | **Notas** | — |
@@ -723,7 +723,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un reporte de ventas para un rango de fechas, con el total vendido, el IVA recaudado y el número de facturas, para evaluar el desempeño del negocio. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-049 |
 | **Criterios de aceptación** | - El reporte acepta `fechaDesde` y `fechaHasta` como parámetros. <br>- Retorna: número total de facturas, monto total sin IVA, IVA total, total con IVA y promedio por factura. |
 | **Notas** | — |
@@ -737,7 +737,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un ranking de los productos más vendidos en un período, para identificar cuáles tienen más demanda. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-050 |
 | **Criterios de aceptación** | - El ranking muestra: nombre del producto, categoría, cantidad vendida y monto generado. <br>- Por defecto muestra el top 10. El límite es configurable. <br>- Se puede filtrar por rango de fechas. |
 | **Notas** | — |
@@ -751,7 +751,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un dashboard con los indicadores más importantes del negocio, para tener una visión general rápida sin necesidad de buscar en múltiples reportes. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-054 |
 | **Criterios de aceptación** | - El dashboard muestra: ventas del día, semana y mes, número de clientes registrados, cantidad de productos activos, productos agotados y valor total del inventario. |
 | **Notas** | — |
@@ -771,7 +771,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero crear la clase JPA `DetalleFactura` que actualmente falta, para poder registrar el detalle de productos en cada factura generada. |
 | **Responsable** | Backend + BD |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Existe la clase `DetalleFactura.java` en el paquete `model`. <br>- Tiene clave compuesta (idFactura + idProducto) con `@IdClass` o `@EmbeddedId`. <br>- Los campos `cantidad` y `precioUnitario` tienen sus anotaciones de validación. <br>- El esquema SQL ya existe en `SCRIPTS_POSTGRES.sql`; solo falta la entidad Java. |
 | **Notas** | La tabla `DetalleFactura` ya existe en la base de datos. |
@@ -785,7 +785,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero agregar el campo `imagen` (URL) a la entidad Producto, para que los clientes puedan ver una foto del artículo en el catálogo. |
 | **Responsable** | Backend + BD |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - La entidad `Producto` tiene un campo `imagenUrl` de tipo `String`, opcional (nullable). <br>- El campo aparece en el DTO de respuesta de producto. <br>- El esquema PostgreSQL se actualiza con `ALTER TABLE` o a través del `ddl-auto=update` de Hibernate. |
 | **Notas** | Usar `ddl-auto=update` permite que Hibernate añada la columna automáticamente, pero verificar que no cause problemas. |
@@ -799,7 +799,7 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero asegurar que los valores del enum `TipoDocumento` en Java y en PostgreSQL sean exactamente los mismos, para evitar errores al insertar o leer usuarios. |
 | **Responsable** | BD |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Backlog |
+| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - El enum PostgreSQL `tipo_documento_enum` incluye todos los valores del enum Java: CC, TI, CE, PASAPORTE, NIT, RUT, OTRO. <br>- O bien el enum Java se reduce a solo los valores que tiene PostgreSQL. <br>- El equipo decide cuál de las dos opciones aplicar y lo documenta. |
 | **Notas** | Actualmente Java tiene 7 valores y PostgreSQL solo tiene 4. Es una inconsistencia que causará errores en producción. |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -184,17 +184,49 @@ Cada HU sigue el formato estándar de Scrum:
 
 ---
 
-#### TT-005 — Corregir mapeo JPA: tipos, herencia, enums, indices y timestamps
+#### TT-005 — Corregir mapeo JPA (epica, partida en sub-items)
+
+> Este item se partio en TT-005a, TT-005b y TT-005c por tamano (probable >13 pts). El item original TT-005 queda como referencia de la epica completa.
+
+#### TT-005a — Migrar tipos monetarios a BigDecimal
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como desarrollador de BD, quiero corregir todos los problemas de mapeo entre el esquema PostgreSQL y las entidades JPA, para que la aplicacion arranque y funcione correctamente sin errores silenciosos en produccion. |
+| **Historia** | Como desarrollador de BD, quiero migrar todos los campos monetarios de `double` a `BigDecimal`, para eliminar errores de redondeo en calculos de IVA y totales de factura. |
 | **Responsable** | BD + Backend |
-| **Prioridad** | 🔴 Must Have |
+| **Prioridad** | 🔴 Must Have (Sprint 1 — bloqueante absoluto) |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
-| **Criterios de aceptación** | - Cambiar `double` → `BigDecimal` en todas las entidades que representen dinero: `Producto.precioUnitario`, `ItemsCarrito.subtotal`, `Factura.subtotal`, `Factura.iva`, `Factura.total`. <br>- Eliminar `@Inheritance(JOINED)` en `Usuario`: `Cliente` y `Empleado` pasan a ser entidades independientes con FK `id_usuario UNIQUE` (perfiles 1:1). <br>- Anotar todos los enums con `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` para que Hibernate los mapee al tipo PostgreSQL nativo. <br>- Agregar `@CreationTimestamp`/`@UpdateTimestamp` en todos los campos `created_at`/`updated_at` que en SQL tienen `DEFAULT CURRENT_TIMESTAMP`. <br>- Agregar indices en todas las FK (`@Index` en `@Table`) para evitar seq-scans en joins frecuentes. <br>- El enum `TipoDocumento` queda alineado entre Java (CC, TI, CE, PASAPORTE, NIT, RUT, OTRO) y PostgreSQL (mismos valores). |
-| **Notas** | `double` para dinero causa errores de redondeo en sumas de IVA. `@Inheritance(JOINED)` esta roto porque el esquema SQL no comparte PK con `Usuario` (usa FK separada). Ver ADR-0004 y ADR-0006. |
+| **Criterios de aceptación** | - Cambiar `double` → `BigDecimal` en `Producto.precioUnitario`, `ItemsCarrito.subtotal`, `Factura.subtotal`, `Factura.iva`, `Factura.total`, `IntentoPago.monto`, `DetalleFactura.precioUnitario`, `DetalleFactura.subtotal`. <br>- Configurar Jackson `ObjectMapper` para no usar notacion cientifica al serializar. <br>- Constructores de `BigDecimal` siempre con `String` (no `double`) para evitar perdida de precision. <br>- Migracion Flyway que convierte columnas `DOUBLE PRECISION` → `NUMERIC(15,2)`. |
+| **Notas** | Bloqueante absoluto antes de cualquier HU que toque dinero. Ver ADR-0004. |
+
+---
+
+#### TT-005b — Eliminar @Inheritance(JOINED) y migrar Cliente/Empleado a perfiles 1:1
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador de BD, quiero refactorizar `Cliente` y `Empleado` como entidades independientes con FK `id_usuario UNIQUE`, para alinear el modelo JPA con el esquema PostgreSQL real y permitir que un Usuario tenga ambos perfiles si fuera necesario. |
+| **Responsable** | BD + Backend |
+| **Prioridad** | 🔴 Must Have (Sprint 2 candidato) |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Eliminar `@Inheritance(JOINED)` de `Usuario`. <br>- `Cliente` y `Empleado` quedan como `@Entity` independientes con `@Id` propio o `@MapsId` referenciando `Usuario.id`. <br>- Use case de registro crea Usuario + perfil correspondiente en transaccion atomica. <br>- Repositorios y casos de uso afectados se actualizan. |
+| **Notas** | `@Inheritance(JOINED)` esta roto porque el SQL no comparte PK con Usuario. Ver ADR-0006. |
+
+---
+
+#### TT-005c — Anotar enums + agregar timestamps + indices en FKs
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador de BD, quiero anotar correctamente enums, timestamps de auditoria e indices en FKs, para que Hibernate genere consultas eficientes y mapee a tipos PostgreSQL nativos. |
+| **Responsable** | BD + Backend |
+| **Prioridad** | 🔴 Must Have (Sprint 2 candidato) |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Anotar todos los enums con `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` para que mapeen al tipo PostgreSQL nativo. <br>- Agregar `@CreationTimestamp` / `@UpdateTimestamp` en campos `created_at` / `updated_at` con `DEFAULT CURRENT_TIMESTAMP` en SQL. <br>- Agregar `@Index` en `@Table` para todas las FKs frecuentes (categoria_id, cliente_id, producto_id, factura_id, etc.). <br>- Verificar que `TipoDocumento` Java (CC, TI, CE, PASAPORTE, NIT, RUT, OTRO) coincida exactamente con el enum PostgreSQL. |
+| **Notas** | Sin `@JdbcTypeCode`, Hibernate convierte enums a VARCHAR perdiendo el tipo nativo. Sin indices en FKs, Postgres hace seq-scan en joins frecuentes. |
 
 ---
 
@@ -1112,17 +1144,49 @@ Cada HU sigue el formato estándar de Scrum:
 ---
 
 
-#### TT-068 — Refactorizar a arquitectura Hexagonal por bounded context
+#### TT-068 — Refactor a Hexagonal+DDD (epica, partida en sub-items)
+
+> Este item se partio en TT-068a, TT-068b y TT-068c por tamano (probable >21 pts: 7 bounded contexts). El item original TT-068 queda como referencia de la epica completa.
+
+#### TT-068a — Estructura hexagonal base + bounded context Identidad
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como equipo de desarrollo, quiero reorganizar los paquetes del backend siguiendo arquitectura Hexagonal por bounded context, para que cada contexto pueda evolucionar de forma independiente y la logica de dominio sea testeable sin Spring. |
+| **Historia** | Como equipo de desarrollo, quiero crear la estructura hexagonal base y migrar el bounded context Identidad, para establecer la convencion arquitectonica que seguiran los demas contextos. |
 | **Responsable** | Backend |
-| **Prioridad** | 🔴 Must have |
+| **Prioridad** | 🔴 Must have (Sprint 1 — bloqueante absoluto) |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
-| **Criterios de aceptación** | - Los paquetes siguen la estructura: `com.tiendaq.<contexto>.domain`, `com.tiendaq.<contexto>.application`, `com.tiendaq.<contexto>.infrastructure`. <br>- Los 7 bounded contexts estan definidos: identidad, catalogo, inventario, carrito, pedidos, pagos, reportes. <br>- La logica de dominio no tiene dependencias de Spring (solo POJO/records). <br>- Los tests de dominio se ejecutan sin Spring Boot (`@SpringBootTest` solo para slices de integracion). |
-| **Notas** | Ver ADR-0001. Este refactor es prerrequisito para implementar use cases por contexto en Fase 2. |
+| **Criterios de aceptación** | - Crear estructura `com.tiendaq.<contexto>.{domain,application,infrastructure}`. <br>- Migrar Usuario, Cliente, Empleado a `com.tiendaq.identidad`. <br>- Crear puertos: `UsuarioRepositoryPort`, `TokenPort`, `NotificacionPort`. <br>- Tests de dominio se ejecutan sin Spring Boot. <br>- `domain/` no tiene dependencias de Spring ni JPA. |
+| **Notas** | Ver ADR-0001. Bloqueante absoluto antes de cualquier otro context migration o HU. |
+
+---
+
+#### TT-068b — Migrar Catalogo + Inventario
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como equipo de desarrollo, quiero migrar los bounded contexts Catalogo e Inventario a la estructura hexagonal, para aislar la logica de productos y stock del resto del sistema. |
+| **Responsable** | Backend |
+| **Prioridad** | 🔴 Must have (Sprint 2 candidato) |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Mover Producto, Categoria a `com.tiendaq.catalogo`. <br>- Mover StockLevel, StockEntry, StockReservation a `com.tiendaq.inventario`. <br>- Crear puertos `ProductoRepositoryPort`, `StockReservationPort`. <br>- Use cases de creacion/actualizacion/consulta de productos quedan en `application/`. |
+| **Notas** | Depende de TT-068a. |
+
+---
+
+#### TT-068c — Migrar Carrito + Pedidos + Pagos + Reportes
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como equipo de desarrollo, quiero migrar los bounded contexts restantes (Carrito, Pedidos, Pagos, Reportes) a la estructura hexagonal, para completar el refactor arquitectonico. |
+| **Responsable** | Backend |
+| **Prioridad** | 🔴 Must have (Sprint 2 o 3 candidato) |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Mover Carrito + ItemCarrito a `com.tiendaq.carrito`. <br>- Mover Factura + DetalleFactura a `com.tiendaq.pedidos`. <br>- Mover IntentoPago + WompiPagoAdapter a `com.tiendaq.pagos` (con `PagoPort` en domain). <br>- Crear `com.tiendaq.reportes` (read-models, sin aggregate propio). |
+| **Notas** | Depende de TT-068a y TT-068b. Ultimo paso del refactor. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -787,8 +787,8 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Prioridad** | 🟡 Should have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
-| **Criterios de aceptación** | - La entidad `Producto` tiene un campo `imagenUrl` de tipo `String`, opcional (nullable). <br>- El campo aparece en el DTO de respuesta de producto. <br>- El esquema PostgreSQL se actualiza con `ALTER TABLE` o a través del `ddl-auto=update` de Hibernate. |
-| **Notas** | Usar `ddl-auto=update` permite que Hibernate añada la columna automáticamente, pero verificar que no cause problemas. |
+| **Criterios de aceptación** | - La entidad `Producto` tiene un campo `imagenUrl` de tipo `String`, opcional (nullable). <br>- El campo aparece en el DTO de respuesta de producto. <br>- La columna se agrega via migracion Flyway `V2__add_producto_imagen.sql` (NO via `ddl-auto=update`). |
+| **Notas** | `ddl-auto=update` debe estar deshabilitado tras US-058 (Flyway). Toda modificacion de schema usa migraciones Flyway versionadas. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -239,8 +239,8 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Prioridad** | 🔴 Must Have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-003 |
-| **Criterios de aceptación** | - Las peticiones sin token retornan 401. <br>- Las peticiones con token expirado retornan 401. <br>- Las peticiones con token válido pero rol insuficiente retornan 403. <br>- Los tokens tienen una expiración configurable (por defecto 24 horas). |
-| **Notas** | — |
+| **Criterios de aceptación** | - Las peticiones sin token retornan 401. <br>- Las peticiones con token expirado retornan 401. <br>- Las peticiones con token valido pero rol insuficiente retornan 403. <br>- El access token expira en **15 minutos**. <br>- El refresh token expira en **7 dias** y se rota en cada uso (el anterior queda invalidado). <br>- Existe el endpoint `POST /api/auth/refresh` que recibe el refresh token y retorna un nuevo par access/refresh. <br>- Los refresh tokens se almacenan hasheados en tabla `refresh_token(id, usuario_id, token_hash, expires_at, used_at)`. |
+| **Notas** | 24h de expiracion es un antipatron de seguridad: cualquier token robado tiene acceso durante un dia completo. 15min + refresh rotation minimiza la ventana de exposicion. Ver ADR-0002. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -806,6 +806,84 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 ---
 
+### Épica 12 — Integración con Pasarela de Pagos
+
+**Descripción:** Conectar el checkout con Wompi sandbox para procesar pagos reales en un entorno de prueba. Incluye el flujo completo: iniciar intento, redirigir al usuario, recibir webhook de confirmacion, reconciliar con la factura y aislar la API externa via anticorrupcion layer.
+
+**¿Por qué es necesaria?** El plan define un MVP academico con pagos reales en sandbox. Sin esta epica el checkout solo simula el pago localmente, lo que no cumple el objetivo de aprender integracion con pasarelas reales.
+
+---
+
+#### US-046 — Iniciar un intento de pago con Wompi
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero iniciar el pago de mi carrito a traves de Wompi sandbox, para completar mi compra con un metodo de pago real. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-027 |
+| **Criterios de aceptación** | - El endpoint `POST /api/pagos/iniciar` crea un registro `IntentoPago` en estado PENDIENTE. <br>- Retorna la URL de redireccion de Wompi sandbox para que el frontend redirija al usuario. <br>- El `IntentoPago` tiene: idCarrito, monto, moneda (COP), referencia unica y timestamp. |
+| **Notas** | Wompi sandbox no requiere tarjeta real. Ver ADR-0003. |
+
+---
+
+#### US-047 — Recibir webhook de confirmacion de Wompi
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como sistema, quiero recibir el webhook de Wompi cuando el pago se confirma o rechaza, para actualizar el estado del intento de pago de forma automatica. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-027 |
+| **Criterios de aceptación** | - El endpoint `POST /api/pagos/webhook` es publico pero valida la firma HMAC de Wompi. <br>- Si el evento es APPROVED, el `IntentoPago` pasa a APROBADO y se dispara la generacion de factura. <br>- Si el evento es DECLINED o ERROR, el `IntentoPago` pasa a RECHAZADO y el carrito vuelve a CON_PRODUCTOS. <br>- El webhook es idempotente: registros duplicados del mismo `transaction_id` se ignoran (tabla `processed_webhook(transaction_id UNIQUE)`). |
+| **Notas** | Sin idempotencia, Wompi puede enviar el mismo evento mas de una vez y se generaria una factura duplicada. |
+
+---
+
+#### US-048 — Reconciliar IntentoPago con la Factura
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como sistema, quiero vincular el `IntentoPago` aprobado con la `Factura` generada, para tener trazabilidad completa del ciclo de vida de un pago. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-027 |
+| **Criterios de aceptación** | - La `Factura` tiene un campo `intentoPagoId` que referencia al `IntentoPago`. <br>- La transaccion de Flyway crea la factura y actualiza el `IntentoPago` atomicamente. <br>- El endpoint `GET /api/facturas/{id}` incluye el `intentoPagoId` en la respuesta. |
+| **Notas** | — |
+
+---
+
+#### US-049 — Manejar pagos rechazados o fallidos
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero recibir retroalimentacion clara cuando mi pago es rechazado, para poder intentarlo nuevamente o elegir otro metodo. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-027 |
+| **Criterios de aceptación** | - Si el pago es rechazado, el carrito vuelve a estado CON_PRODUCTOS. <br>- El frontend muestra el motivo del rechazo (INSUFFICIENT_FUNDS, INVALID_CARD, etc.). <br>- El cliente puede reintentar el pago sin perder los items del carrito. |
+| **Notas** | — |
+
+---
+
+#### US-050 — Capa anticorrupcion para Wompi (ACL)
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador Backend, quiero aislar la integracion con Wompi detras de un puerto y un adaptador, para poder cambiar de pasarela en el futuro sin modificar la logica de dominio. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Existe una interfaz `PasarelaPort` en el paquete de dominio con metodos `iniciarPago` y `validarWebhook`. <br>- La implementacion `WompiAdapter` esta en el paquete `infrastructure/pago`. <br>- Los tests del dominio usan un mock de `PasarelaPort`, no la clase de Wompi directamente. |
+| **Notas** | Patron Hexagonal. Ver ADR-0001 y ADR-0003. |
+
+---
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -107,14 +107,7 @@ Cada HU sigue el formato estándar de Scrum:
 | 🟠 Could have | Necesario pero puede esperar a que lo crítico esté listo. |
 | 🟢 Won't have | Deseable. Se aborda si hay tiempo disponible. |
 
-### Estados posibles de una historia
-
-| Estado | Descripción |
-|--------|------------|
-| 📋 Por hacer | Aún no se ha iniciado |
-| 🔄 En curso | Alguien está trabajando en ella actualmente |
-| 👁️ En revisión | Terminada, esperando revisión del equipo |
-| ✅ Hecho | Completada y aceptada por el Product Owner |
+> **Estado de cada item:** se gestiona en [GitHub Projects](https://github.com/orgs/K-Forge/projects/2) (columnas: Por hacer → En curso → En revisión → Hecho). No se duplica aquí.
 
 ---
 
@@ -135,7 +128,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo, quiero tener definidas las convenciones de código y la estructura de carpetas del proyecto, para que todos trabajemos de forma coherente sin pisarnos. |
 | **Responsable** | Todos (revisar AGENTS.md y la guia org-level CONTRIBUTING) |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Las convenciones de commits (Conventional Commits) están documentadas y todos las siguen. <br>- La estructura de ramas Git Flow está activa (`main`, `develop`, `feature/*`). <br>- El equipo acordó cómo nombrar branches, clases y métodos. |
 | **Notas** | La guia de contribucion vive en el repo org-level [`K-Forge/.github/blob/main/CONTRIBUTING.md`](https://github.com/K-Forge/.github/blob/main/CONTRIBUTING.md). El `AGENTS.md` local complementa con contexto especifico de TiendaQ. |
@@ -149,7 +141,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero crear DTOs (objetos de transferencia de datos) para cada entidad, para que la API nunca exponga directamente las entidades JPA ni datos sensibles como contraseñas. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RNF-019 |
 | **Criterios de aceptación** | - Existe un DTO de request y uno de response para cada entidad (Usuario, Producto, Carrito, etc.). <br>- Ningún endpoint retorna directamente una entidad JPA. <br>- El campo `contrasena` nunca aparece en ninguna respuesta de la API. |
 | **Notas** | Actualmente todos los controllers exponen entidades JPA directamente. Esto es un problema de seguridad crítico. |
@@ -163,7 +154,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero configurar Spring Security con autenticación JWT, para que todos los endpoints estén protegidos y solo los usuarios autorizados puedan acceder. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-002, RF-003, RF-004 |
 | **Criterios de aceptación** | - Existe un `SecurityFilterChain` configurado. <br>- Los endpoints públicos (login, registro) no requieren token. <br>- Los endpoints protegidos retornan 401 si no hay token válido. <br>- Los endpoints de administrador retornan 403 si el rol no es suficiente. |
 | **Notas** | La dependencia de Spring Security ya está en el `pom.xml`, pero sin configuración activa. |
@@ -177,7 +167,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero un manejador global de excepciones, para que todos los errores de la API tengan un formato JSON consistente y no expongan detalles internos del sistema. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-058, RF-059 |
 | **Criterios de aceptación** | - Existe una clase `@ControllerAdvice` que captura excepciones. <br>- Todos los errores retornan JSON con: `timestamp`, `status`, `error`, `message`, `path`. <br>- Ningún error expone stack traces ni nombres de tablas de la base de datos. |
 | **Notas** | El paquete `exception/` existe en el proyecto pero está vacío. |
@@ -195,7 +184,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero migrar todos los campos monetarios de `double` a `BigDecimal`, para eliminar errores de redondeo en calculos de IVA y totales de factura. |
 | **Responsable** | BD + Backend |
 | **Prioridad** | 🔴 Must Have (Sprint 1 — bloqueante absoluto) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Cambiar `double` → `BigDecimal` en `Producto.precioUnitario`, `ItemsCarrito.subtotal`, `Factura.subtotal`, `Factura.iva`, `Factura.total`, `IntentoPago.monto`, `DetalleFactura.precioUnitario`, `DetalleFactura.subtotal`. <br>- Configurar Jackson `ObjectMapper` para no usar notacion cientifica al serializar. <br>- Constructores de `BigDecimal` siempre con `String` (no `double`) para evitar perdida de precision. <br>- Migracion Flyway que convierte columnas `DOUBLE PRECISION` → `NUMERIC(15,2)`. |
 | **Notas** | Bloqueante absoluto antes de cualquier HU que toque dinero. Ver ADR-0004. |
@@ -209,7 +197,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero refactorizar `Cliente` y `Empleado` como entidades independientes con FK `id_usuario UNIQUE`, para alinear el modelo JPA con el esquema PostgreSQL real y permitir que un Usuario tenga ambos perfiles si fuera necesario. |
 | **Responsable** | BD + Backend |
 | **Prioridad** | 🔴 Must Have (Sprint 2 candidato) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Eliminar `@Inheritance(JOINED)` de `Usuario`. <br>- `Cliente` y `Empleado` quedan como `@Entity` independientes con `@Id` propio o `@MapsId` referenciando `Usuario.id`. <br>- Use case de registro crea Usuario + perfil correspondiente en transaccion atomica. <br>- Repositorios y casos de uso afectados se actualizan. |
 | **Notas** | `@Inheritance(JOINED)` esta roto porque el SQL no comparte PK con Usuario. Ver ADR-0006. |
@@ -223,7 +210,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero anotar correctamente enums, timestamps de auditoria e indices en FKs, para que Hibernate genere consultas eficientes y mapee a tipos PostgreSQL nativos. |
 | **Responsable** | BD + Backend |
 | **Prioridad** | 🔴 Must Have (Sprint 2 candidato) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Anotar todos los enums con `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` para que mapeen al tipo PostgreSQL nativo. <br>- Agregar `@CreationTimestamp` / `@UpdateTimestamp` en campos `created_at` / `updated_at` con `DEFAULT CURRENT_TIMESTAMP` en SQL. <br>- Agregar `@Index` en `@Table` para todas las FKs frecuentes (categoria_id, cliente_id, producto_id, factura_id, etc.). <br>- Verificar que `TipoDocumento` Java (CC, TI, CE, PASAPORTE, NIT, RUT, OTRO) coincida exactamente con el enum PostgreSQL. |
 | **Notas** | Sin `@JdbcTypeCode`, Hibernate convierte enums a VARCHAR perdiendo el tipo nativo. Sin indices en FKs, Postgres hace seq-scan en joins frecuentes. |
@@ -237,7 +223,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Frontend, quiero estructurar el proyecto Angular 21 con Atomic Design, Signals y PrimeNG, para tener una base solida, escalable y coherente con el design system de K-Forge. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-072 |
 | **Criterios de aceptación** | - Estructura de carpetas Atomic Design: `atoms/`, `molecules/`, `organisms/`, `templates/`, `pages/`. <br>- Patron Container/Presentational: los containers viven en `pages/`, los presentacionales en `organisms/` y `molecules/`. <br>- `AuthService` con Signal store de sesion (sin NgRx). <br>- `authInterceptor` que inyecta el JWT en cada peticion, captura 401 e intenta refresh antes de fallar. <br>- `authGuard` y `roleGuard` para proteger rutas segun autenticacion y rol. <br>- PrimeNG instalado con tema custom que usa los design tokens de K-Forge (negro/amarillo en `_tokens.scss`). <br>- Lazy loading configurado por feature en `app.routes.ts`. <br>- `environment.ts` con la URL base de la API por ambiente. |
 | **Notas** | Signals reemplaza NgRx para el MVP (10% del codigo, misma reactividad). PrimeNG proporciona los componentes UI; los design tokens de K-Forge personalizan el tema sin reescribir componentes. |
@@ -259,7 +244,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario nuevo, quiero registrarme con mis datos personales (nombre, apellido, documento, teléfono, correo, dirección y contraseña), para crear mi cuenta y poder hacer compras. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-001 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/registro` crea un Usuario y un Cliente en una sola transacción. <br>- La contraseña se almacena con hash BCrypt (nunca en texto plano). <br>- Si el correo, documento o teléfono ya existen, retorna 409 con mensaje claro. <br>- El formulario de Angular valida los campos en tiempo real antes de enviar. <br>- La respuesta nunca incluye la contraseña. |
 | **Notas** | Actualmente la creación de usuario y cliente son operaciones separadas y las contraseñas no se hashean. |
@@ -273,7 +257,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario registrado, quiero iniciar sesión con mi correo y contraseña, para acceder al sistema con las funciones que corresponden a mi rol. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-002 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/login` retorna un token JWT válido al ingresar credenciales correctas. <br>- El token contiene el ID del usuario, su correo y su rol. <br>- Si las credenciales son incorrectas, retorna 401 con mensaje genérico (no indicar si el error es en el correo o en la contraseña, por seguridad). <br>- El frontend almacena el token de forma segura y redirige al usuario según su rol. |
 | **Notas** | —  |
@@ -287,7 +270,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero validar el token JWT en cada petición a un endpoint protegido, para garantizar que solo usuarios autenticados accedan a los recursos. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-003 |
 | **Criterios de aceptación** | - Las peticiones sin token retornan 401. <br>- Las peticiones con token expirado retornan 401. <br>- Las peticiones con token valido pero rol insuficiente retornan 403. <br>- El access token expira en **15 minutos**. <br>- El refresh token expira en **7 dias** y se rota en cada uso (el anterior queda invalidado). <br>- Existe el endpoint `POST /api/auth/refresh` que recibe el refresh token y retorna un nuevo par access/refresh. <br>- Los refresh tokens se almacenan hasheados en tabla `refresh_token(id, usuario_id, token_hash, expires_at, used_at)`. |
 | **Notas** | 24h de expiracion es un antipatron de seguridad: cualquier token robado tiene acceso durante un dia completo. 15min + refresh rotation minimiza la ventana de exposicion. Ver ADR-0002. |
@@ -301,7 +283,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero restringir el acceso a cada endpoint según el rol del usuario autenticado, para que un cliente no pueda hacer lo que solo puede hacer un empleado o administrador. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-004 |
 | **Criterios de aceptación** | - Los endpoints de gestión de productos y stock solo son accesibles por VENDEDOR y ADMINISTRADOR. <br>- Los endpoints de gestión de usuarios solo son accesibles por ADMINISTRADOR. <br>- Los endpoints de carrito, perfil e historial son accesibles por CLIENTE. <br>- El rol ADMINISTRADOR hereda los permisos de VENDEDOR. |
 | **Notas** | — |
@@ -315,7 +296,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero poder cerrar sesión, para que mi sesión quede invalidada y nadie más pueda usarla desde el mismo dispositivo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-005 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/logout` recibe el access token y el refresh token. <br>- El `jti` (JWT ID) del access token se registra en la tabla `revoked_token(jti, user_id, expires_at)`. <br>- El refresh token se marca como usado en la tabla `refresh_token`. <br>- Peticiones posteriores con ese access token retornan 401 (el filtro JWT verifica contra `revoked_token`). <br>- Un job `@Scheduled` limpia automaticamente los registros de `revoked_token` cuyo `expires_at` ya paso, para no crecer indefinidamente. <br>- El frontend elimina ambos tokens del almacenamiento local y redirige al login. |
 | **Notas** | El RNF-013 (stateless) y RF-005 (logout efectivo) son contradictorios si no existe la tabla de blacklist. La tabla `revoked_token` resuelve la contradiccion: el sistema es stateless por defecto pero invalida tokens explicitamente cuando es necesario. Ver ADR-0002. |
@@ -329,7 +309,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario, quiero recuperar mi contraseña si la olvidé, para poder volver a acceder sin necesitar al administrador. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-006 |
 | **Criterios de aceptación** | - El endpoint `POST /api/auth/recuperar` acepta un correo y genera un token temporal. <br>- El token temporal se registra en consola o en un endpoint dedicado (no se envía correo real). <br>- Con el token temporal el usuario puede establecer una nueva contraseña hasheada. |
 | **Notas** | El envío real de correos está fuera del alcance del proyecto. |
@@ -349,7 +328,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero crear un producto con nombre, categoría, precio e imagen (URL), para que esté disponible en el catálogo de la tienda. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - El endpoint `POST /api/productos` solo es accesible por VENDEDOR y ADMINISTRADOR. <br>- El producto requiere: nombre, categoría (enum), precio unitario positivo. <br>- La imagen es una URL externa opcional. <br>- El nombre debe ser único dentro de la misma categoría. <br>- El formulario de Angular valida todos los campos antes de enviar. |
 | **Notas** | La entidad `Producto` actualmente no tiene campo `imagen`. Debe añadirse (ver TT-044). |
@@ -363,7 +341,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero editar los datos de un producto existente, para mantener el catalogo actualizado y preciso ante cambios de proveedor, ajustes de precio o renovacion de fotografia. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-011 |
 | **Criterios de aceptación** | - El endpoint `PUT /api/productos/{id}` actualiza nombre, categoría, precio e imagen. <br>- Si el producto no existe, retorna 404. <br>- La validación de unicidad de nombre por categoría se mantiene al editar. |
 | **Notas** | — |
@@ -377,7 +354,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero eliminar un producto que no tiene stock ni compras asociadas, para mantener el catálogo limpio y actualizado. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-012 |
 | **Criterios de aceptación** | - Si el producto tiene stock o está en facturas, el endpoint retorna 409 con un mensaje descriptivo. <br>- Si se puede eliminar, retorna 204 (sin contenido). <br>- El frontend muestra un diálogo de confirmación antes de eliminar. |
 | **Notas** | — |
@@ -391,7 +367,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cualquier usuario, quiero ver la lista de productos con paginación, filtros por categoría y búsqueda por nombre, para encontrar lo que necesito sin ver todo el catálogo de golpe. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-010, RF-013 |
 | **Criterios de aceptación** | - El endpoint `GET /api/productos` soporta los parámetros: `page`, `size`, `sortBy`, `direction`. <br>- El endpoint `GET /api/productos/categoria/{categoria}` filtra por categoría. <br>- La respuesta incluye metadatos de paginación: `totalElements`, `totalPages`, `currentPage`. <br>- El frontend muestra los productos en una grilla con controles de paginación. |
 | **Notas** | Actualmente el endpoint no soporta paginación ni `Pageable`. |
@@ -411,7 +386,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero buscar productos escribiendo solo parte del nombre, para encontrar lo que busco sin tener que escribirlo completo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-014 |
 | **Criterios de aceptación** | - El endpoint acepta un parámetro `nombre` y hace búsqueda ILIKE (insensible a mayúsculas). <br>- Si no hay resultados, retorna lista vacía (no error). <br>- El parámetro debe tener al menos 2 caracteres. <br>- El frontend tiene un campo de búsqueda que se activa al escribir. |
 | **Notas** | Requiere agregar `findByNombreContainingIgnoreCase` al repositorio. |
@@ -425,7 +399,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero filtrar productos por rango de precio (mínimo y máximo), para ver solo los que puedo pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-015 |
 | **Criterios de aceptación** | - El endpoint acepta parámetros `precioMin` y `precioMax` (ambos opcionales). <br>- Si solo se proporciona `precioMin`, filtra productos con precio ≥ precioMin. <br>- Si solo se proporciona `precioMax`, filtra productos con precio ≤ precioMax. <br>- El frontend tiene controles de rango de precio. |
 | **Notas** | — |
@@ -439,7 +412,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver el detalle completo de un producto (nombre, categoría, precio, imagen y stock disponible), para decidir si lo compro. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-017 |
 | **Criterios de aceptación** | - La pantalla de detalle consume el endpoint `GET /api/productos/{id}`. <br>- Si el stock es 0, se muestra la etiqueta "Agotado". <br>- Hay un botón para agregar al carrito (deshabilitado si está agotado). <br>- La imagen se muestra si existe URL; si no, se muestra un placeholder. |
 | **Notas** | — |
@@ -461,7 +433,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero agregar un producto a mi carrito indicando la cantidad deseada, para ir seleccionando lo que quiero comprar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-019 |
 | **Criterios de aceptación** | - Si el cliente no tiene carrito activo, el sistema lo crea automáticamente con estado VACÍO. <br>- Si el producto ya está en el carrito, se suma la cantidad. <br>- Si el stock es insuficiente, retorna 409 con la cantidad disponible. <br>- El precio unitario se registra al momento de agregar (no cambia aunque el producto se actualice después). <br>- El estado del carrito cambia a CON_PRODUCTOS. |
 | **Notas** | — |
@@ -475,7 +446,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero cambiar la cantidad de un producto en mi carrito, para ajustar mi pedido antes de pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-020 |
 | **Criterios de aceptación** | - Si la nueva cantidad es válida, se actualiza el item. <br>- Si la cantidad es 0, el item se elimina. <br>- Si el carrito queda vacío, el estado cambia a VACÍO. <br>- El sistema valida que el stock sea suficiente para la nueva cantidad. |
 | **Notas** | — |
@@ -489,7 +459,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero eliminar un producto específico de mi carrito, para cambiar de opinión sobre ese artículo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-021 |
 | **Criterios de aceptación** | - El item se elimina del carrito. <br>- Si el carrito queda vacío, el estado cambia a VACÍO. <br>- El frontend muestra confirmación antes de eliminar. |
 | **Notas** | — |
@@ -503,7 +472,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver mi carrito con la lista de productos, el subtotal, el IVA (19%) y el total, para saber exactamente cuánto voy a pagar. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must Have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-023 |
 | **Criterios de aceptación** | - La respuesta incluye: lista de items, subtotal, IVA (19% del subtotal), total. <br>- Si el cliente no tiene carrito activo, retorna estructura vacía (no error). <br>- El carrito es accesible desde cualquier pantalla (componente lateral o modal). |
 | **Notas** | — |
@@ -517,7 +485,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero validar el stock disponible cada vez que se agrega o modifica un item en el carrito, para no permitir vender más de lo que hay en inventario. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-024 |
 | **Criterios de aceptación** | - Si el stock es insuficiente, la operación se rechaza con 409 indicando la cantidad disponible. <br>- La validación ocurre tanto al agregar como al modificar la cantidad. <br>- El calculo de disponible considera reservas activas: `disponible = cantidad - SUM(reservas activas)`. |
 | **Notas** | Acompañante de HU-020 (agregar producto al carrito). Diferente de TT-067: TT-024 es lectura (validacion sincrona), TT-067 es escritura (reserva pesimista durante checkout). |
@@ -531,7 +498,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero que el carrito siga una máquina de estados definida, para que el flujo de compra sea coherente y no se pueda saltar pasos. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-025 |
 | **Criterios de aceptación** | - Las transiciones válidas son: VACÍO → CON_PRODUCTOS, CON_PRODUCTOS → VACÍO, CON_PRODUCTOS → EN_PROCESO_DE_PAGO, EN_PROCESO_DE_PAGO → PAGO_PENDIENTE, PAGO_PENDIENTE → PAGO_EXITOSO, EN_PROCESO_DE_PAGO → CON_PRODUCTOS. <br>- Cualquier otra transición retorna 400 con mensaje descriptivo. |
 | **Notas** | — |
@@ -551,7 +517,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero iniciar el proceso de pago desde mi carrito, para formalizar mi compra. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-026 |
 | **Criterios de aceptación** | - El sistema re-valida el stock de todos los productos del carrito al iniciar el checkout. <br>- Si hay stock insuficiente en algún producto, retorna 409 con el detalle. <br>- Si todo está bien, el estado del carrito cambia a EN_PROCESO_DE_PAGO. <br>- El frontend muestra un resumen del carrito antes de confirmar. |
 | **Notas** | — |
@@ -565,7 +530,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero seleccionar el método de pago que prefiero (PSE, tarjeta de crédito, tarjeta débito, efectivo o transferencia), para completar mi compra. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - Los métodos disponibles son los definidos en el enum `MetodoPago`. <br>- Al seleccionar, el estado del carrito cambia a PAGO_PENDIENTE. <br>- El método seleccionado queda registrado para la factura. |
 | **Notas** | No se realiza procesamiento real del pago. Solo se registra el método. |
@@ -579,7 +543,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero generar una factura completa con el detalle de los productos comprados cuando el cliente confirma el pago, para tener un registro permanente e inmutable de la transacción. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Se crea un registro en `Factura` con: fecha, subtotal, IVA (19%), total, método de pago, referencia al cliente, al empleado/sistema y al carrito. <br>- Se crean registros en `DetalleFactura` con el precio y cantidad de cada producto al momento de la compra. <br>- El estado del carrito cambia a PAGO_EXITOSO. <br>- Todo ocurre en una sola transacción atómica (si algo falla, todo se revierte). |
 | **Notas** | Depende de TT-043 (entidad `DetalleFactura`). |
@@ -593,7 +556,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero descontar automáticamente el stock de cada producto vendido al generar la factura, para que el inventario siempre refleje la realidad. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-032 |
 | **Criterios de aceptación** | - El descuento de stock es parte de la misma transacción que genera la factura. <br>- Si el stock de algún producto es insuficiente en el momento exacto de facturar, toda la operación se revierte (rollback). <br>- El stock resultante nunca puede ser negativo. <br>- **Depende de TT-067:** la confirmacion del pago consume la reserva existente (no decrementa stock real desde cero). |
 | **Notas** | Depende de TT-067 (reserva). El decremento real ocurre al consumir la reserva. |
@@ -607,7 +569,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero cancelar el proceso de pago si aún no lo he confirmado, para volver a mi carrito y seguir comprando o modificar mi pedido. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-029 |
 | **Criterios de aceptación** | - Solo se puede cancelar si el carrito está en estado EN_PROCESO_DE_PAGO. <br>- Al cancelar, el estado vuelve a CON_PRODUCTOS. <br>- Los items del carrito permanecen intactos. <br>- **Las reservas de stock asociadas se liberan automaticamente,** restaurando el `disponible` del producto. |
 | **Notas** | Depende de TT-067 (reservas) — la cancelacion debe disparar la liberacion. |
@@ -621,7 +582,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver mi historial de compras con el detalle de cada factura, para llevar control de todo lo que he comprado. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-030, RF-031 |
 | **Criterios de aceptación** | - La lista está paginada y ordenada por fecha descendente (más reciente primero). <br>- Cada factura muestra: número, fecha, total y método de pago. <br>- Al hacer clic en una factura, se ve el detalle completo con productos, cantidades y precios. <br>- Un cliente solo puede ver sus propias facturas. |
 | **Notas** | — |
@@ -641,7 +601,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero registrar un ingreso de stock para un producto indicando la cantidad y la fecha, para actualizar el inventario cuando llegue mercancía. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-034 |
 | **Criterios de aceptación** | - El endpoint `POST /api/stock` crea un registro de stock asociado al producto. <br>- La cantidad debe ser un entero positivo. <br>- Si el producto no existe, retorna 404. <br>- El frontend tiene un formulario para ingresar la cantidad. |
 | **Notas** | — |
@@ -655,7 +614,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero ver el inventario general con una alerta visual para los productos con poco stock, para saber cuándo debo pedir más mercancía. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-036, RF-037 |
 | **Criterios de aceptación** | - Los productos con stock ≤ 5 unidades se marcan como "stock bajo". <br>- Existe un endpoint dedicado `GET /api/stock/bajo` que retorna solo los productos con stock bajo. <br>- El frontend muestra un indicador visual destacado (color rojo o etiqueta) para estos productos. |
 | **Notas** | El umbral de 5 unidades debe ser configurable en el futuro. |
@@ -675,7 +633,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver la lista de todos los usuarios del sistema con paginación y búsqueda por nombre, correo o documento, para tener control sobre quién tiene acceso. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-039, RF-045 |
 | **Criterios de aceptación** | - El endpoint retorna la lista paginada de usuarios sin incluir contraseñas. <br>- Se puede buscar por documento (exacto) o por correo (parcial). <br>- Se puede filtrar por tipo de usuario (REGISTRADO, SIN_REGISTRAR). |
 | **Notas** | — |
@@ -689,7 +646,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero crear cuentas de empleados (vendedor o administrador), para darles acceso al sistema con los permisos correspondientes. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-041 |
 | **Criterios de aceptación** | - Se crea el Usuario y el Empleado en una sola transacción. <br>- La contraseña se hashea con BCrypt. <br>- El tipo de empleado puede ser VENDEDOR o ADMINISTRADOR. |
 | **Notas** | — |
@@ -703,7 +659,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero editar los datos de cualquier usuario (nombre, apellido, teléfono, dirección, correo), para asegurar que los datos de contacto y facturacion del usuario sean precisos en todo momento. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-042 |
 | **Criterios de aceptación** | - No se puede modificar el tipo ni número de documento. <br>- Si se cambia el correo, se valida que no exista en otro usuario. <br>- Si se proporciona nueva contraseña, se hashea; si no, la existente no cambia. |
 | **Notas** | — |
@@ -717,7 +672,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero desactivar o eliminar una cuenta de usuario que ya no la necesita, para mantener el sistema ordenado sin perder el historial de compras. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-043 |
 | **Criterios de aceptación** | - **Usuario**: soft-delete con campo `deleted_at TIMESTAMP NULL`. Se anula la visibilidad pero se preserva el historial de facturas. El usuario no puede iniciar sesion una vez eliminado. <br>- **Producto**: soft-delete con `deleted_at`. Deja de aparecer en el catalogo pero las facturas existentes conservan la referencia. <br>- **Carrito**: hard-delete solo si esta vacio y tiene mas de 30 dias de abandono. Un carrito con items no se elimina fisicamente. <br>- Las entidades con soft-delete usan `@SQLDelete` + `@Where(clause = "deleted_at IS NULL")` en Hibernate para que las queries normales no retornen registros eliminados. <br>- El frontend muestra confirmacion antes de desactivar y aclara que el historial se preserva. |
 | **Notas** | El soft-delete tambien sirve como registro de auditoria basico: `deleted_at` indica cuando fue desactivado. Se complementa con `audit_log` (TT-066) para tener el `deleted_by`. Ver ADR-0007. |
@@ -737,7 +691,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero ver mi información de perfil y poder editar mi teléfono y dirección, para mantener mis datos de contacto actualizados. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-046, RF-047 |
 | **Criterios de aceptación** | - El endpoint `GET /api/perfil` retorna los datos del usuario autenticado sin incluir la contraseña. <br>- Solo se pueden editar: teléfono y dirección (no nombre, apellido ni documento). <br>- El cambio de correo requiere verificar la contraseña actual. |
 | **Notas** | — |
@@ -751,7 +704,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario autenticado, quiero cambiar mi contraseña verificando la actual, para mantener mi cuenta segura. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-048 |
 | **Criterios de aceptación** | - El usuario debe proveer la contraseña actual (verificación con BCrypt). <br>- La nueva contraseña debe tener mínimo 8 caracteres, una mayúscula y un número. <br>- La nueva contraseña se almacena hasheada con BCrypt. |
 | **Notas** | — |
@@ -773,7 +725,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un reporte de ventas para un rango de fechas, con el total vendido, el IVA recaudado y el número de facturas, para evaluar el desempeño del negocio. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-049 |
 | **Criterios de aceptación** | - El reporte acepta `fechaDesde` y `fechaHasta` como parámetros. <br>- Retorna: número total de facturas, monto total sin IVA, IVA total, total con IVA y promedio por factura. |
 | **Notas** | — |
@@ -787,7 +738,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un ranking de los productos más vendidos en un período, para identificar cuáles tienen más demanda. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-050 |
 | **Criterios de aceptación** | - El ranking muestra: nombre del producto, categoría, cantidad vendida y monto generado. <br>- Por defecto muestra el top 10. El límite es configurable. <br>- Se puede filtrar por rango de fechas. |
 | **Notas** | — |
@@ -801,7 +751,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un dashboard con los indicadores más importantes del negocio, para tener una visión general rápida sin necesidad de buscar en múltiples reportes. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-054 |
 | **Criterios de aceptación** | - El dashboard muestra: ventas del día, semana y mes, número de clientes registrados, cantidad de productos activos, productos agotados y valor total del inventario. |
 | **Notas** | — |
@@ -821,7 +770,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero crear la clase JPA `DetalleFactura` que actualmente falta, para poder registrar el detalle de productos en cada factura generada. |
 | **Responsable** | Backend + BD |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-028 |
 | **Criterios de aceptación** | - Existe la clase `DetalleFactura.java` en el paquete `model`. <br>- Tiene clave compuesta (idFactura + idProducto) con `@IdClass` o `@EmbeddedId`. <br>- Los campos `cantidad` y `precioUnitario` tienen sus anotaciones de validación. <br>- El esquema SQL ya existe en `SCRIPTS_POSTGRES.sql`; solo falta la entidad Java. |
 | **Notas** | La tabla `DetalleFactura` ya existe en la base de datos. |
@@ -835,7 +783,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero agregar el campo `imagen` (URL) a la entidad Producto, para que los clientes puedan ver una foto del artículo en el catálogo. |
 | **Responsable** | Backend + BD |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-008 |
 | **Criterios de aceptación** | - La entidad `Producto` tiene un campo `imagenUrl` de tipo `String`, opcional (nullable). <br>- El campo aparece en el DTO de respuesta de producto. <br>- La columna se agrega via migracion Flyway `V2__add_producto_imagen.sql` (NO via `ddl-auto=update`). |
 | **Notas** | `ddl-auto=update` debe estar deshabilitado tras EN-058 (Flyway). Toda modificacion de schema usa migraciones Flyway versionadas. |
@@ -849,7 +796,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero asegurar que los valores del enum `TipoDocumento` en Java y en PostgreSQL sean exactamente los mismos, para evitar errores al insertar o leer usuarios. |
 | **Responsable** | BD |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - El enum PostgreSQL `tipo_documento_enum` incluye todos los valores del enum Java: CC, TI, CE, PASAPORTE, NIT, RUT, OTRO. <br>- O bien el enum Java se reduce a solo los valores que tiene PostgreSQL. <br>- El equipo decide cuál de las dos opciones aplicar y lo documenta. |
 | **Notas** | Actualmente Java tiene 7 valores y PostgreSQL solo tiene 4. Es una inconsistencia que causará errores en producción. |
@@ -871,7 +817,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero iniciar el pago de mi carrito a traves de Wompi sandbox, para completar mi compra con un metodo de pago real. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - El endpoint `POST /api/pagos/iniciar` crea un registro `IntentoPago` en estado PENDIENTE. <br>- Retorna la URL de redireccion de Wompi sandbox para que el frontend redirija al usuario. <br>- El `IntentoPago` tiene: idCarrito, monto, moneda (COP), referencia unica y timestamp. |
 | **Notas** | Wompi sandbox no requiere tarjeta real. Ver ADR-0003. |
@@ -885,7 +830,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero recibir el webhook de Wompi cuando el pago se confirma o rechaza, para actualizar el estado del intento de pago de forma automatica. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - El endpoint `POST /api/pagos/webhook` es publico pero valida la firma HMAC de Wompi. <br>- Si el evento es APPROVED, el `IntentoPago` pasa a APROBADO y se dispara la generacion de factura. <br>- Si el evento es DECLINED o ERROR, el `IntentoPago` pasa a RECHAZADO y el carrito vuelve a CON_PRODUCTOS. <br>- El webhook es idempotente: registros duplicados del mismo `transaction_id` se ignoran (tabla `processed_webhook(transaction_id UNIQUE)`). |
 | **Notas** | Sin idempotencia, Wompi puede enviar el mismo evento mas de una vez y se generaria una factura duplicada. |
@@ -899,7 +843,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero vincular el `IntentoPago` aprobado con la `Factura` generada, para tener trazabilidad completa del ciclo de vida de un pago. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - La `Factura` tiene un campo `intentoPagoId` que referencia al `IntentoPago`. <br>- La transaccion de Flyway crea la factura y actualiza el `IntentoPago` atomicamente. <br>- El endpoint `GET /api/facturas/{id}` incluye el `intentoPagoId` en la respuesta. |
 | **Notas** | — |
@@ -913,7 +856,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero recibir retroalimentacion clara cuando mi pago es rechazado, para poder intentarlo nuevamente o elegir otro metodo. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - Si el pago es rechazado, el carrito vuelve a estado CON_PRODUCTOS. <br>- El frontend muestra el motivo del rechazo (INSUFFICIENT_FUNDS, INVALID_CARD, etc.). <br>- El cliente puede reintentar el pago sin perder los items del carrito. |
 | **Notas** | — |
@@ -927,7 +869,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador Backend, quiero aislar la integracion con Wompi detras de un puerto y un adaptador, para poder cambiar de pasarela en el futuro sin modificar la logica de dominio. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Existe una interfaz `PasarelaPort` en el paquete de dominio con metodos `iniciarPago` y `validarWebhook`. <br>- La implementacion `WompiAdapter` esta en el paquete `infrastructure/pago`. <br>- Los tests del dominio usan un mock de `PasarelaPort`, no la clase de Wompi directamente. |
 | **Notas** | Patron Hexagonal. Ver ADR-0001 y ADR-0003. |
@@ -949,7 +890,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador, quiero que el backend y el frontend tengan Dockerfiles, para poder ejecutar el proyecto en cualquier maquina sin instalar Java, Maven o Node manualmente. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - `app/backend/tiendaq/Dockerfile` construye la imagen del backend (multi-stage: build Maven + runtime JRE). <br>- `app/frontend/Dockerfile` construye la imagen del frontend (multi-stage: build Angular + Nginx). <br>- Ambas imagenes construyen sin errores con `docker build`. |
 | **Notas** | — |
@@ -963,7 +903,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador nuevo, quiero levantar todo el entorno local con un solo comando, para empezar a contribuir en menos de 30 minutos. |
 | **Responsable** | Backend + BD |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - `docker-compose.yml` levanta: backend, frontend, PostgreSQL y Mailhog (SMTP local). <br>- `docker compose up` levanta todo sin configuracion adicional. <br>- Las variables de entorno estan en `.env.example` con valores por defecto para local. |
 | **Notas** | — |
@@ -977,7 +916,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo, quiero que cada PR ejecute automaticamente los tests y el build, para detectar errores antes de mergear a develop. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Existe `.github/workflows/ci.yml` con jobs: lint → test → build. <br>- Los tests usan Testcontainers (PostgreSQL real, no H2 embebido). <br>- El pipeline falla si alguna prueba falla. <br>- El pipeline pasa en menos de 5 minutos. |
 | **Notas** | — |
@@ -991,7 +929,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador de BD, quiero versionar el esquema con Flyway, para que cualquier cambio de base de datos sea reproducible, reversible y auditable. |
 | **Responsable** | BD + Backend |
 | **Prioridad** | 🔴 Must have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Existe `app/backend/tiendaq/src/main/resources/db/migration/V1__init.sql` con el esquema completo. <br>- `spring.jpa.hibernate.ddl-auto=none` en todos los perfiles. <br>- Al arrancar la aplicacion, Flyway ejecuta las migraciones pendientes automaticamente. <br>- `SCRIPTS_POSTGRES.sql` sigue siendo la fuente de referencia humana pero no se ejecuta en tiempo de arranque. |
 | **Notas** | Ver ADR-0005. Sin Flyway, los cambios de esquema pueden perderse o romperse entre integrantes. |
@@ -1005,7 +942,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador, quiero tener perfiles de ambiente separados, para que las credenciales de produccion nunca aparezcan en el codigo ni en el repositorio. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Existen `application-local.yml`, `application-dev.yml` y `application-staging.yml`. <br>- Las credenciales sensibles se leen de variables de entorno (`DB_USER`, `DB_PASSWORD`, `JWT_SECRET`, `WOMPI_KEY`). <br>- `.env.example` documenta todas las variables requeridas con valores de ejemplo seguros. |
 | **Notas** | — |
@@ -1019,7 +955,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo, quiero un ambiente de staging accesible por URL publica, para poder demostrar el proyecto sin necesidad de correrlo localmente. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - El backend esta desplegado en Render o Railway (free tier). <br>- La base de datos PostgreSQL esta provisionada en el mismo proveedor. <br>- La URL publica responde en `GET /actuator/health` con `{"status":"UP"}`. |
 | **Notas** | Sin backups. No es produccion real. |
@@ -1031,7 +966,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero ver el resultado de mi pago luego de ser redirigido desde Wompi, para saber si mi compra fue exitosa o si debo intentarlo de nuevo. |
 | **Responsable** | Frontend + Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-027 |
 | **Criterios de aceptación** | - Al volver de Wompi, el frontend consulta `GET /api/pagos/{id}` para obtener el estado del intento. <br>- Si APROBADO: pantalla de exito con resumen de factura y boton a historial. <br>- Si RECHAZADO: pantalla de error con motivo y boton de reintentar. <br>- La pantalla no depende solo de los parametros de URL (que pueden ser manipulados): siempre consulta el backend. |
 | **Notas** | El webhook (TT-047) es el que realmente confirma el pago; esta US solo muestra el resultado al usuario. |
@@ -1046,7 +980,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como estudiante que aprende sobre Habeas Data, quiero implementar un checkbox de consentimiento al registrarse, para experimentar con los requisitos basicos de la Ley 1581/2012 en un contexto academico. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - El formulario de registro incluye un checkbox "Acepto la politica de privacidad" (obligatorio). <br>- El backend registra `consentimiento_fecha` y `consentimiento_ip` en el usuario. <br>- El endpoint de registro rechaza con 400 si el campo no es `true`. |
 | **Notas** | Solo educativo. El proyecto no saldra a produccion real. Las obligaciones formales completas de la ley (anonimizacion, exportacion) quedan fuera del alcance del MVP. |
@@ -1061,7 +994,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador, quiero que el backend exponga endpoints de salud y metricas, para poder monitorear el estado del sistema sin acceder directamente al servidor. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - `GET /actuator/health` retorna `{"status":"UP"}` cuando todo esta bien. <br>- `GET /actuator/info` retorna version y nombre del proyecto. <br>- Los logs se emiten en formato JSON (Logback) con nivel configurable por ambiente. <br>- Los endpoints de actuator estan protegidos y solo son accesibles con rol ADMINISTRADOR (excepto `/health`). |
 | **Notas** | Sin Grafana, Prometheus ni Loki para el MVP. |
@@ -1076,7 +1008,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como desarrollador, quiero que la API este documentada automaticamente con OpenAPI, para que cualquier integrante pueda explorar y probar los endpoints sin necesidad de Postman. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RNF-020 |
 | **Criterios de aceptación** | - La dependencia `springdoc-openapi-starter-webmvc-ui` esta en el `pom.xml`. <br>- `GET /swagger-ui.html` muestra la UI de Swagger con todos los endpoints documentados. <br>- `GET /v3/api-docs` retorna el YAML de OpenAPI. <br>- El archivo `docs/api/openapi.yaml` esta commiteado y se actualiza con cada cambio de la API. |
 | **Notas** | El archivo commiteado es la fuente de verdad para generar colecciones de Postman. |
@@ -1091,7 +1022,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero limitar la cantidad de intentos en los endpoints de autenticacion y checkout, para prevenir ataques de fuerza bruta y abuso del servicio. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Limite de 5 intentos de login por IP en 15 minutos (retorna 429 al exceder). <br>- Limite de 3 registros por IP por hora. <br>- Limite de 10 inicios de checkout por IP por hora. <br>- El rate limit se implementa como filtro Spring (Bucket4j) en la cadena: `CorsFilter → RateLimitFilter → JwtAuthFilter`. |
 | **Notas** | Ver ADR del rate limit en `docs/adr/`. |
@@ -1106,7 +1036,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero recibir un correo con el resumen de mi factura al completar una compra, para tener constancia del pedido sin necesitar acceder a la aplicacion. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Al generar la factura, el sistema envia un correo al cliente con: numero de factura, fecha, total y lista de productos. <br>- El envio se realiza de forma asincrona (no bloquea la respuesta al cliente). <br>- En ambiente local, el correo se captura con Mailhog (en docker-compose). <br>- En staging se usa Gmail SMTP (`kforge.dev@gmail.com` + App Password). <br>- La implementacion usa un puerto `NotificacionPort` con un adaptador `GmailSmtpAdapter` intercambiable. |
 | **Notas** | Patron Hexagonal: el dominio no conoce Gmail. El adaptador se configura por ambiente. |
@@ -1121,7 +1050,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero que las acciones criticas (crear usuario, eliminar producto, generar factura) queden registradas en un log de auditoria, para poder rastrear quien hizo que y cuando. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Existe la tabla `audit_log(id, usuario_id, accion, entidad, entidad_id, antes, despues, fecha)`. <br>- Las acciones CREATE, UPDATE, DELETE en Usuario, Producto, Factura y StockEntry quedan registradas. <br>- El campo `antes` y `despues` guardan el estado en JSON. <br>- El registro es inmutable: no hay endpoint de eliminacion de audit_log. |
 | **Notas** | La auditoria no reemplaza a los logs del sistema; los complementa con contexto de negocio. |
@@ -1136,7 +1064,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero reservar el stock de los productos cuando un cliente inicia el checkout, para evitar que dos clientes compren el mismo articulo al mismo tiempo. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟡 Should have |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-032 |
 | **Criterios de aceptación** | - Al iniciar checkout, se crean registros en `stock_reservation(id, producto_id, carrito_id, cantidad, expires_at)`. <br>- El `expires_at` se fija a 10 minutos desde la creacion. <br>- Un job `@Scheduled` libera las reservas expiradas cada minuto. <br>- Al confirmar la factura, las reservas se convierten en descuento real de stock. <br>- Si no hay stock disponible (considerando reservas activas de otros carritos), el checkout retorna 409. |
 | **Notas** | Sin reservas hay race condition: dos clientes pueden confirmar el pago del mismo ultimo articulo. Ver ADR-0010. |
@@ -1155,7 +1082,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo de desarrollo, quiero crear la estructura hexagonal base y migrar el bounded context Identidad, para establecer la convencion arquitectonica que seguiran los demas contextos. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have (Sprint 1 — bloqueante absoluto) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Crear estructura `com.tiendaq.<contexto>.{domain,application,infrastructure}`. <br>- Migrar Usuario, Cliente, Empleado a `com.tiendaq.identidad`. <br>- Crear puertos: `UsuarioRepositoryPort`, `TokenPort`, `NotificacionPort`. <br>- Tests de dominio se ejecutan sin Spring Boot. <br>- `domain/` no tiene dependencias de Spring ni JPA. |
 | **Notas** | Ver ADR-0001. Bloqueante absoluto antes de cualquier otro context migration o HU. |
@@ -1169,7 +1095,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo de desarrollo, quiero migrar los bounded contexts Catalogo e Inventario a la estructura hexagonal, para aislar la logica de productos y stock del resto del sistema. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have (Sprint 2 candidato) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Mover Producto, Categoria a `com.tiendaq.catalogo`. <br>- Mover StockLevel, StockEntry, StockReservation a `com.tiendaq.inventario`. <br>- Crear puertos `ProductoRepositoryPort`, `StockReservationPort`. <br>- Use cases de creacion/actualizacion/consulta de productos quedan en `application/`. |
 | **Notas** | Depende de TT-068a. |
@@ -1183,7 +1108,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como equipo de desarrollo, quiero migrar los bounded contexts restantes (Carrito, Pedidos, Pagos, Reportes) a la estructura hexagonal, para completar el refactor arquitectonico. |
 | **Responsable** | Backend |
 | **Prioridad** | 🔴 Must have (Sprint 2 o 3 candidato) |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Mover Carrito + ItemCarrito a `com.tiendaq.carrito`. <br>- Mover Factura + DetalleFactura a `com.tiendaq.pedidos`. <br>- Mover IntentoPago + WompiPagoAdapter a `com.tiendaq.pagos` (con `PagoPort` en domain). <br>- Crear `com.tiendaq.reportes` (read-models, sin aggregate propio). |
 | **Notas** | Depende de TT-068a y TT-068b. Ultimo paso del refactor. |
@@ -1205,7 +1129,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como empleado, quiero actualizar manualmente la cantidad de un registro de stock existente, para corregir errores de conteo o ajustes de inventario fisico. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-038 |
 | **Criterios de aceptación** | - El endpoint `PUT /api/inventario/stock/{id}` actualiza la cantidad. <br>- El cambio queda registrado en `audit_log` con motivo. <br>- Solo accesible para empleados. |
 | **Notas** | Diferido a Fase 2. El MVP solo permite ENTRADA via HU-032; correcciones manuales requieren intervencion en BD. |
@@ -1219,7 +1142,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un reporte de ventas agrupadas por categoria de producto, para identificar que segmentos generan mas ingresos. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-052 |
 | **Criterios de aceptación** | - Reporte con total vendido y cantidad de unidades por categoria. <br>- Filtros por rango de fechas. |
 | **Notas** | Diferido a Fase 2. HU-040 cubre ventas totales; HU-070 segmenta por categoria. |
@@ -1233,7 +1155,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como administrador, quiero ver un reporte de ventas atribuidas a cada empleado, para evaluar el desempeño individual. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-053 |
 | **Criterios de aceptación** | - Reporte con total vendido por empleado. <br>- Requiere asociar Factura a empleado responsable (no esta en el modelo MVP). |
 | **Notas** | Diferido a Fase 2. Requiere ampliar Factura con `empleado_id`. |
@@ -1247,7 +1168,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero descargar mi factura en formato PDF, para tener una copia fisica como soporte tributario. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Endpoint `GET /api/pedidos/facturas/{id}/pdf` retorna PDF. <br>- Plantilla con logo K-Forge, datos de cliente, detalle de productos, totales. |
 | **Notas** | Diferido a Fase 2. MVP solo muestra factura en pantalla. |
@@ -1261,7 +1181,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como sistema, quiero registrar cada vez que un usuario consulta una factura, para tener trazabilidad completa de accesos a documentos fiscales. |
 | **Responsable** | Backend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Cada `GET /api/pedidos/facturas/{id}` registra una entrada en `audit_log`. <br>- Solo accesible al admin. |
 | **Notas** | Diferido a Fase 2. TT-066 cubre auditoria de mutaciones; TT-073 amplia a lecturas. |
@@ -1275,7 +1194,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como usuario en dispositivo movil, quiero que la interfaz se adapte al tamaño de mi pantalla, para usar la tienda comodamente desde el celular o tablet. |
 | **Responsable** | Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-070 |
 | **Criterios de aceptación** | - Breakpoints definidos para mobile (<768px), tablet (<1024px), desktop. <br>- Layout, menu y tablas se adaptan. <br>- Probado en Chrome devtools y dispositivos reales. |
 | **Notas** | Diferido a Fase 2. EN-006 entrega base desktop-first. |
@@ -1289,7 +1207,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero vaciar todo mi carrito con un solo clic, para empezar de cero rapidamente sin tener que eliminar items uno por uno. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-022 |
 | **Criterios de aceptación** | - Endpoint `DELETE /api/carrito/items` elimina todos los items del carrito activo. <br>- Frontend muestra confirmacion antes de vaciar. |
 | **Notas** | Diferido a Fase 2. MVP usa HU-022 (eliminar uno por uno). |
@@ -1303,7 +1220,6 @@ Cada HU sigue el formato estándar de Scrum:
 | **Historia** | Como cliente, quiero buscar productos combinando multiples criterios simultaneos (nombre + categoria + rango de precio + disponibilidad), para encontrar exactamente lo que necesito en una sola consulta. |
 | **Responsable** | Backend + Frontend |
 | **Prioridad** | 🟠 Could have `[Fase 2]` |
-| **Estado** | 📋 Por hacer |
 | **RF relacionado** | RF-016 |
 | **Criterios de aceptación** | - Endpoint acepta multiples filtros como query params. <br>- UI con formulario de busqueda avanzada. |
 | **Notas** | Diferido a Fase 2. MVP cubre busqueda por nombre (HU-017) y filtros independientes (HU-018, HU-016). |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -884,6 +884,96 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 ---
 
+### Épica 13 — DevOps e Infraestructura
+
+**Descripcion:** Automatizar el ciclo de vida del proyecto: contenerizacion, migraciones versionadas, perfiles de ambiente, CI/CD y observabilidad basica.
+
+**¿Por que es necesaria?** Sin esta epica el proyecto solo funciona en la maquina de quien lo desarrollo. Los nuevos integrantes no pueden levantar el entorno en menos de 30 minutos, y cualquier cambio de esquema puede romper la base de datos silenciosamente.
+
+---
+
+#### US-055 — Dockerfiles para backend y frontend
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador, quiero que el backend y el frontend tengan Dockerfiles, para poder ejecutar el proyecto en cualquier maquina sin instalar Java, Maven o Node manualmente. |
+| **Responsable** | Backend + Frontend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - `app/backend/tiendaq/Dockerfile` construye la imagen del backend (multi-stage: build Maven + runtime JRE). <br>- `app/frontend/Dockerfile` construye la imagen del frontend (multi-stage: build Angular + Nginx). <br>- Ambas imagenes construyen sin errores con `docker build`. |
+| **Notas** | — |
+
+---
+
+#### US-056 — docker-compose para entorno local completo
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador nuevo, quiero levantar todo el entorno local con un solo comando, para empezar a contribuir en menos de 30 minutos. |
+| **Responsable** | Backend + BD |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - `docker-compose.yml` levanta: backend, frontend, PostgreSQL y Mailhog (SMTP local). <br>- `docker compose up` levanta todo sin configuracion adicional. <br>- Las variables de entorno estan en `.env.example` con valores por defecto para local. |
+| **Notas** | — |
+
+---
+
+#### US-057 — Pipeline CI/CD con GitHub Actions
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como equipo, quiero que cada PR ejecute automaticamente los tests y el build, para detectar errores antes de mergear a develop. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Existe `.github/workflows/ci.yml` con jobs: lint → test → build. <br>- Los tests usan Testcontainers (PostgreSQL real, no H2 embebido). <br>- El pipeline falla si alguna prueba falla. <br>- El pipeline pasa en menos de 5 minutos. |
+| **Notas** | — |
+
+---
+
+#### US-058 — Migrar esquema a Flyway
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador de BD, quiero versionar el esquema con Flyway, para que cualquier cambio de base de datos sea reproducible, reversible y auditable. |
+| **Responsable** | BD + Backend |
+| **Prioridad** | 🔴 Must have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Existe `app/backend/tiendaq/src/main/resources/db/migration/V1__init.sql` con el esquema completo. <br>- `spring.jpa.hibernate.ddl-auto=none` en todos los perfiles. <br>- Al arrancar la aplicacion, Flyway ejecuta las migraciones pendientes automaticamente. <br>- `SCRIPTS_POSTGRES.sql` sigue siendo la fuente de referencia humana pero no se ejecuta en tiempo de arranque. |
+| **Notas** | Ver ADR-0005. Sin Flyway, los cambios de esquema pueden perderse o romperse entre integrantes. |
+
+---
+
+#### US-059 — Perfiles de ambiente (local/dev/staging)
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como desarrollador, quiero tener perfiles de ambiente separados, para que las credenciales de produccion nunca aparezcan en el codigo ni en el repositorio. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Existen `application-local.yml`, `application-dev.yml` y `application-staging.yml`. <br>- Las credenciales sensibles se leen de variables de entorno (`DB_USER`, `DB_PASSWORD`, `JWT_SECRET`, `WOMPI_KEY`). <br>- `.env.example` documenta todas las variables requeridas con valores de ejemplo seguros. |
+| **Notas** | — |
+
+---
+
+#### US-060 — Despliegue en staging (Render/Railway)
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como equipo, quiero un ambiente de staging accesible por URL publica, para poder demostrar el proyecto sin necesidad de correrlo localmente. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - El backend esta desplegado en Render o Railway (free tier). <br>- La base de datos PostgreSQL esta provisionada en el mismo proveedor. <br>- La URL publica responde en `GET /actuator/health` con `{"status":"UP"}`. |
+| **Notas** | Sin backups. No es produccion real. |
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1140,115 +1140,98 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 ## Propuesta de Sprints
 
-> Cada Sprint tiene una duración sugerida de **2 semanas**. El Product Owner puede ajustar el alcance de cada sprint según la velocidad del equipo.
+> **Estado:** PENDIENTE DE PLANNING POKER. La asignacion de USs a sprints **no esta hecha**. Solo Sprint 1 esta fijado (USs fundacionales, no negociables). Sprints 2-8 se asignan **despues** de la sesion de planning poker conjunta.
+>
+> **Por que no estan asignados:** Estimar capacidad de sprint requiere conocer puntos por US. Los puntos se obtienen del planning poker. Asignar USs a sprints sin estimates concretos lleva a sobrecargar o subcargar sprints. Es lo opuesto a planeacion agil.
 
-### Sprint 1 — Base técnica (US-001 a US-006, US-043, US-045)
+### Capacity teorica del sprint
 
-**Objetivo:** Dejar el proyecto con la infraestructura técnica mínima para que todos puedan trabajar sin bloquearse entre sí.
+| Parametro | Valor |
+|-----------|-------|
+| Duracion | 2 semanas |
+| Devs activos | 3 (Brian, Camilo, Aleja, Miguel — Brian PO con dedicacion menor) |
+| Horas/dev/semana | 10 h |
+| **Capacity bruta** | **60 h/sprint** |
 
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-001 | Estructura de carpetas y convenciones | Todos |
-| US-002 | Implementar DTOs en Backend | Backend |
-| US-003 | Configurar Spring Security con JWT | Backend |
-| US-004 | Manejador global de errores | Backend |
-| US-005 | Sincronizar esquema BD con JPA | BD |
-| US-006 | Estructura base del Frontend Angular | Frontend |
-| US-043 | Crear entidad JPA DetalleFactura | Backend + BD |
-| US-045 | Alinear enum TipoDocumento | BD |
+Capacity bruta no es lo mismo que capacity efectiva. La capacity real se ajusta cada sprint segun:
+- Velocity observada en el sprint anterior (puntos completados / capacity bruta).
+- Imprevistos (parciales, semana de exposiciones, etc.).
+- Compromiso real del equipo en planning.
 
----
-
-### Sprint 2 — Autenticación (US-007 a US-012)
-
-**Objetivo:** Que cualquier usuario pueda registrarse, iniciar sesión y que el sistema controle el acceso según su rol.
-
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-007 | Registro de nuevo cliente | Backend + Frontend |
-| US-008 | Inicio de sesión | Backend + Frontend |
-| US-009 | Validación automática del token JWT | Backend |
-| US-010 | Autorización por roles | Backend |
-| US-011 | Cierre de sesión | Backend + Frontend |
-| US-012 | Recuperación de contraseña | Backend + Frontend |
+**Primer sprint:** sin velocity historica. Se compromete conservador (~70% de capacity bruta = ~42 h reales) para no sobreprometer.
 
 ---
 
-### Sprint 3 — Productos y catálogo (US-013 a US-019, US-044)
+### Sprint 1 — Fundamentos de codigo (FIJO, no requiere poker)
 
-**Objetivo:** Los empleados pueden gestionar el catálogo y los clientes pueden explorar los productos.
+**Objetivo:** Base tecnica irrenunciable antes de que el equipo pueda construir features. Sin esto, cada PR puede romper el esquema de otro.
 
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-013 | Crear un producto | Backend + Frontend |
-| US-014 | Editar un producto | Backend + Frontend |
-| US-015 | Eliminar un producto | Backend + Frontend |
-| US-016 | Listar productos con paginación y filtros | Backend + Frontend |
-| US-017 | Búsqueda por nombre parcial | Backend + Frontend |
-| US-018 | Filtro por rango de precio | Backend + Frontend |
-| US-019 | Ver detalle de un producto | Frontend |
-| US-044 | Agregar campo imagen a Producto | Backend + BD |
+**Por que va fijo sin planning poker:** Estas USs son must-have de fundacion. No pueden saltarse, no pueden esperar, no compiten con otras prioridades. Son criterio de entrada para que cualquier feature posterior tenga sentido.
 
----
+| ID | Historia | Responsable | Estimacion (pts) |
+|----|----------|-------------|-----------------|
+| US-058 | Migrar esquema a Flyway | BD + Backend | A estimar en poker |
+| US-068 | Refactorizar a arquitectura Hexagonal | Backend | A estimar en poker |
+| US-005 | Corregir mapeo JPA (BigDecimal, JOINED, enums, indices) | BD + Backend | A estimar en poker |
+| US-002 | Implementar DTOs para todas las entidades | Backend | A estimar en poker |
 
-### Sprint 4 — Carrito de compras (US-020 a US-025)
-
-**Objetivo:** El cliente puede agregar productos, gestionarlos y ver su carrito con los totales calculados.
-
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-020 | Agregar producto al carrito | Backend + Frontend |
-| US-021 | Modificar cantidad en el carrito | Backend + Frontend |
-| US-022 | Eliminar producto del carrito | Backend + Frontend |
-| US-023 | Ver carrito con totales | Backend + Frontend |
-| US-024 | Validación de stock en tiempo real | Backend |
-| US-025 | Máquina de estados del carrito | Backend |
+**Nota:** Los puntos de estas USs igualmente se estiman en el planning poker para calibrar la escala del equipo y obtener una primera medicion de velocity al cierre del Sprint 1.
 
 ---
 
-### Sprint 5 — Checkout y facturación (US-026 a US-031)
+### Sprints 2-8 — Pool de USs sin asignar
 
-**Objetivo:** El cliente puede completar su compra y recibir una factura. El inventario se actualiza automáticamente.
+**Listas separadas por prioridad MoSCoW.** Asignar a sprints despues del planning poker.
 
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-026 | Iniciar proceso de checkout | Backend + Frontend |
-| US-027 | Seleccionar método de pago | Backend + Frontend |
-| US-028 | Generar factura | Backend |
-| US-029 | Descontar stock al facturar | Backend |
-| US-030 | Cancelar proceso de checkout | Backend + Frontend |
-| US-031 | Ver historial de facturas | Backend + Frontend |
+#### Pool Must have (asignar primero)
 
----
+US-001, US-003, US-004, US-006, US-007, US-008, US-009, US-010, US-011, US-013, US-014, US-015, US-016, US-019, US-020, US-022, US-023, US-024, US-025, US-026, US-027, US-028, US-029, US-031, US-043, US-044, US-045, US-046, US-047, US-055, US-067, US-059.
 
-### Sprint 6 — Inventario, usuarios y perfil (US-032 a US-039)
+#### Pool Should have (asignar despues de cubrir Must)
 
-**Objetivo:** Los empleados gestionan el inventario, el administrador gestiona usuarios y cada usuario puede ver su perfil.
+US-012, US-017, US-018, US-021, US-030, US-032, US-033, US-034, US-036, US-037, US-038, US-039, US-040, US-041, US-042, US-062, US-063.
 
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-032 | Registrar ingreso de stock | Backend + Frontend |
-| US-033 | Ver inventario con alertas de stock bajo | Backend + Frontend |
-| US-034 | Listar usuarios con búsqueda y paginación | Backend + Frontend |
-| US-035 | Crear cuenta de empleado | Backend + Frontend |
-| US-036 | Editar datos de usuario | Backend + Frontend |
-| US-037 | Eliminar o desactivar usuario | Backend + Frontend |
-| US-038 | Ver y editar perfil propio | Backend + Frontend |
-| US-039 | Cambiar contraseña | Backend + Frontend |
+#### Pool Could have (asignar segun capacidad)
+
+US-035, US-048, US-049, US-050, US-051, US-056, US-057, US-060, US-061, US-064, US-065, US-066.
 
 ---
 
-### Sprint 7 — Reportes y estadísticas (US-040 a US-042)
+## Como hacer planning poker correctamente
 
-**Objetivo:** El administrador tiene acceso a información agregada para tomar decisiones de negocio.
+### Preparacion (antes de la sesion)
 
-| ID | Historia | Responsable |
-|----|----------|-------------|
-| US-040 | Reporte de ventas por período | Backend + Frontend |
-| US-041 | Ranking de productos más vendidos | Backend + Frontend |
-| US-042 | Dashboard de KPIs | Backend + Frontend |
+1. **Confirmar Sprint 1.** USs US-002, US-005, US-058, US-068 quedan en Sprint 1 sin discusion. Solo se estiman puntos.
+2. **Acordar la escala de Fibonacci.** Convencion del equipo: 1, 2, 3, 5, 8, 13, 21. Mas de 21 = US demasiado grande, hay que partirla.
+3. **Definir referencia.** Elegir 1 US "ancla" que el equipo entienda completamente y asignarle un valor (ej. US-001 = 3 pts). Todas las demas se comparan contra ella.
+4. **Tener BACKLOG.md a mano.** Cada miembro lee la US (descripcion + criterios de aceptacion) antes de votar.
+5. **Cada miembro vota en privado.** App de poker (Planning Poker Online, Scrum Poker, etc.) o cartas fisicas. Nada de "yo voto X" en voz alta primero — sesga al resto.
+
+### Durante la sesion
+
+1. **Lectura del Product Owner.** Brian lee la US. Resuelve dudas de scope.
+2. **Discusion tecnica corta.** Maximo 3 minutos. Cada uno comenta riesgos, dependencias, complejidad.
+3. **Voto simultaneo.** Todos revelan sus cartas a la vez.
+4. **Si hay consenso (todos misma carta o adyacentes):** se toma la mediana o se acuerda el numero. Pasar a siguiente US.
+5. **Si hay divergencia (ej. uno vota 2, otro vota 13):** los extremos explican su razonamiento. Re-vote. Si persiste, se elige el numero mas alto (mas conservador, mas seguro).
+6. **Registrar puntos en BACKLOG.md.** Llenar la columna "Estimacion (pts)" de cada US estimada.
+
+### Despues de la sesion — asignar a sprints
+
+1. **Calcular puntos por sprint** = capacity bruta (60 h) × factor de conversion. Sin velocity historica, asumir factor conservador: **30-40 pts/sprint** para Sprint 2 (primer sprint con USs ya estimadas).
+2. **Llenar Sprint 2** con USs Must have hasta llegar al limite de puntos. Respetar dependencias (US con `dep: US-XXX` requiere que la dependencia este en Sprint anterior o mismo).
+3. **Repetir para Sprints 3-8** con el resto del Pool Must have, luego Pool Should have, finalmente Pool Could have segun quepa.
+4. **Re-evaluar cada sprint.** Al cerrar Sprint N, calcular velocity real (pts completados / pts comprometidos). Ajustar capacity de Sprint N+1.
+
+### Reglas de oro
+
+- No mover USs de Sprint en curso a otro Sprint sin retro. Si no caben, se sacan al backlog.
+- US con mas de 13 pts → partirla. No ejecutar USs gigantes en un solo sprint.
+- Si un dev no entiende la US lo suficiente para votar → la US no esta lista, no se estima. Volver al refinement.
+- Capacity efectiva real ≠ capacity bruta. Esperar 30-50% menos en los primeros sprints hasta calibrar.
 
 ---
+
 
 ## Registro de Cambios
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1049,6 +1049,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 ---
 
 
+#### US-065 — Notificaciones por correo al confirmar factura
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero recibir un correo con el resumen de mi factura al completar una compra, para tener constancia del pedido sin necesitar acceder a la aplicacion. |
+| **Responsable** | Backend |
+| **Prioridad** | 🟠 Could have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | — |
+| **Criterios de aceptación** | - Al generar la factura, el sistema envia un correo al cliente con: numero de factura, fecha, total y lista de productos. <br>- El envio se realiza de forma asincrona (no bloquea la respuesta al cliente). <br>- En ambiente local, el correo se captura con Mailhog (en docker-compose). <br>- En staging se usa Gmail SMTP (`kforge.dev@gmail.com` + App Password). <br>- La implementacion usa un puerto `NotificacionPort` con un adaptador `GmailSmtpAdapter` intercambiable. |
+| **Notas** | Patron Hexagonal: el dominio no conoce Gmail. El adaptador se configura por ambiente. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -974,6 +974,21 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | **Criterios de aceptación** | - El backend esta desplegado en Render o Railway (free tier). <br>- La base de datos PostgreSQL esta provisionada en el mismo proveedor. <br>- La URL publica responde en `GET /actuator/health` con `{"status":"UP"}`. |
 | **Notas** | Sin backups. No es produccion real. |
 
+#### US-061 — Confirmacion de pago en pantalla del cliente
+
+| Campo | Detalle |
+|-------|---------|
+| **Historia** | Como cliente, quiero ver el resultado de mi pago luego de ser redirigido desde Wompi, para saber si mi compra fue exitosa o si debo intentarlo de nuevo. |
+| **Responsable** | Frontend + Backend |
+| **Prioridad** | 🟡 Should have |
+| **Estado** | 📋 Por hacer |
+| **RF relacionado** | RF-027 |
+| **Criterios de aceptación** | - Al volver de Wompi, el frontend consulta `GET /api/pagos/{id}` para obtener el estado del intento. <br>- Si APROBADO: pantalla de exito con resumen de factura y boton a historial. <br>- Si RECHAZADO: pantalla de error con motivo y boton de reintentar. <br>- La pantalla no depende solo de los parametros de URL (que pueden ser manipulados): siempre consulta el backend. |
+| **Notas** | El webhook (US-047) es el que realmente confirma el pago; esta US solo muestra el resultado al usuario. |
+
+---
+
+
 ## Resumen General
 
 ### Por épica

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,7 +12,7 @@
 
 - [Contexto y Decisiones Arquitectónicas](#contexto-y-decisiones-arquitectónicas)
 - [Equipo y Roles](#equipo-y-roles)
-- [Convención de Historias de Usuario](#convención-de-historias-de-usuario)
+- [Convenciones del backlog](#convenciones-del-backlog)
 - [Épicas e Historias de Usuario](#épicas-e-historias-de-usuario)
   - [Épica 1 — Configuración Base del Proyecto](#épica-1--configuración-base-del-proyecto)
   - [Épica 2 — Autenticación y Autorización](#épica-2--autenticación-y-autorización)
@@ -74,9 +74,27 @@ El proyecto TiendaQ utilizará una arquitectura **monolítica** con una única b
 
 ---
 
-## Convención de Historias de Usuario
+## Convenciones del backlog
 
-Cada historia de usuario sigue el formato estándar de Scrum:
+### Tipos de items
+
+Cada item del backlog se clasifica con un prefijo según su naturaleza:
+
+| Prefijo | Tipo | Qué es | Quién recibe valor |
+|---------|------|--------|--------------------|
+| `HU-` | Historia de Usuario | Funcionalidad visible al usuario final. Sigue el formato "Como X, quiero Y, para Z". | Cliente, Empleado o Administrador |
+| `TT-` | Tarea Técnica | Cambio interno (refactor, fix de modelo, validación) sin valor visible directo. | Equipo de desarrollo (calidad/correctitud) |
+| `EN-` | Enabler / Infraestructura | Habilita features futuras: CI/CD, configuración, observabilidad, scaffolding. | Operación + futuras HUs |
+| `MX-` | Mixto | Combina feature visible con requisito técnico/legal. | Múltiple |
+| `SP-` | Spike (no usado actualmente) | Investigación o prueba de concepto con timebox. | Equipo (decisión técnica) |
+
+**Regla de planeación:** Las TTs y ENs **fundacionales** (bloqueantes) se hacen ANTES que cualquier HU. Las TTs **acompañantes** se ejecutan junto con su HU asociada en el mismo sprint. Las ENs y TTs **independientes** se interleavean según capacidad.
+
+**Regla de estimación:** TODOS los items (HU/TT/EN/MX) se estiman en planning poker con la misma escala Fibonacci. Los puntos miden complejidad+esfuerzo, no valor de negocio.
+
+### Formato de Historias de Usuario
+
+Cada HU sigue el formato estándar de Scrum:
 
 > *Como **[actor]**, quiero **[acción]**, para **[beneficio/valor]**.*
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -166,17 +166,17 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 
 ---
 
-#### US-005 — Verificar y sincronizar el esquema de BD con las entidades JPA
+#### US-005 — Corregir mapeo JPA: tipos, herencia, enums, indices y timestamps
 
 | Campo | Detalle |
 |-------|---------|
-| **Historia** | Como desarrollador de BD, quiero verificar que el esquema PostgreSQL esté perfectamente alineado con las entidades JPA, para evitar errores de mapeo al ejecutar la aplicación. |
-| **Responsable** | BD |
+| **Historia** | Como desarrollador de BD, quiero corregir todos los problemas de mapeo entre el esquema PostgreSQL y las entidades JPA, para que la aplicacion arranque y funcione correctamente sin errores silenciosos en produccion. |
+| **Responsable** | BD + Backend |
 | **Prioridad** | 🔴 Must Have |
 | **Estado** | 📋 Por hacer |
 | **RF relacionado** | — |
-| **Criterios de aceptación** | - Los tipos ENUM en PostgreSQL coinciden exactamente con los enums de Java. <br>- Los nombres de columnas en SQL coinciden con los mapeados en `@Column`. <br>- El enum `TipoDocumento` en Java (que tiene NIT, RUT, OTRO) está alineado con el tipo PostgreSQL (que actualmente no los tiene). |
-| **Notas** | Inconsistencia detectada: `TipoDocumento` en Java tiene valores que no están en el ENUM de PostgreSQL. |
+| **Criterios de aceptación** | - Cambiar `double` → `BigDecimal` en todas las entidades que representen dinero: `Producto.precioUnitario`, `ItemsCarrito.subtotal`, `Factura.subtotal`, `Factura.iva`, `Factura.total`. <br>- Eliminar `@Inheritance(JOINED)` en `Usuario`: `Cliente` y `Empleado` pasan a ser entidades independientes con FK `id_usuario UNIQUE` (perfiles 1:1). <br>- Anotar todos los enums con `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` para que Hibernate los mapee al tipo PostgreSQL nativo. <br>- Agregar `@CreationTimestamp`/`@UpdateTimestamp` en todos los campos `created_at`/`updated_at` que en SQL tienen `DEFAULT CURRENT_TIMESTAMP`. <br>- Agregar indices en todas las FK (`@Index` en `@Table`) para evitar seq-scans en joins frecuentes. <br>- El enum `TipoDocumento` queda alineado entre Java (CC, TI, CE, PASAPORTE, NIT, RUT, OTRO) y PostgreSQL (mismos valores). |
+| **Notas** | `double` para dinero causa errores de redondeo en sumas de IVA. `@Inheritance(JOINED)` esta roto porque el esquema SQL no comparte PK con `Usuario` (usa FK separada). Ver ADR-0004 y ADR-0006. |
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -115,12 +115,12 @@ Cada historia de usuario sigue el formato estándar de Scrum:
 | Campo | Detalle |
 |-------|---------|
 | **Historia** | Como equipo, quiero tener definidas las convenciones de código y la estructura de carpetas del proyecto, para que todos trabajemos de forma coherente sin pisarnos. |
-| **Responsable** | Todos (revisar AGENTS.md y CONTRIBUTING.md) |
+| **Responsable** | Todos (revisar AGENTS.md y la guia org-level CONTRIBUTING) |
 | **Prioridad** | 🔴 Must have |
 | **Estado** | 📋 Backlog |
 | **RF relacionado** | — |
 | **Criterios de aceptación** | - Las convenciones de commits (Conventional Commits) están documentadas y todos las siguen. <br>- La estructura de ramas Git Flow está activa (`main`, `develop`, `feature/*`). <br>- El equipo acordó cómo nombrar branches, clases y métodos. |
-| **Notas** | Ya existe documentación en `CONTRIBUTING.md` y `AGENTS.md`. Revisar que todos la hayan leído. |
+| **Notas** | La guia de contribucion vive en el repo org-level [`K-Forge/.github/blob/main/CONTRIBUTING.md`](https://github.com/K-Forge/.github/blob/main/CONTRIBUTING.md). El `AGENTS.md` local complementa con contexto especifico de TiendaQ. |
 
 ---
 


### PR DESCRIPTION
## Resumen

PR de revision integral del `docs/BACKLOG.md`. Combina dos olas de trabajo en commits granulares y limpios sobre la rama `chore/backlog-revisions`.

### Ola 1 — Hallazgos del PO (1 commit consolidado)

Aplica las 21 correcciones criticas detectadas por Brian (PO) sobre el backlog construido por Camilo (SM):

- **Correcciones criticas:** roles cruzados Aleja/Miguel, CONTRIBUTING ref al repo org-level, estados Kanban `Ready` → `Por hacer`, referencia US-028 → US-043, `ddl-auto=update` → Flyway en US-044.
- **Refinamiento de items existentes:** US-005 (BigDecimal, JOINED, indices), US-006 (Atomic Design + PrimeNG + Signals), US-009 (JWT 15min + refresh 7d con rotacion), US-011 (revoked_token), US-037 (soft-delete por entidad).
- **Items nuevos:** Epica 12 Pagos (US-046..050) + Epica 13 DevOps (US-055..060) + items transversales (US-051 Habeas Data, US-061 confirmacion pago, US-062 observabilidad, US-063 OpenAPI, US-064 rate limit, US-065 notificaciones, US-066 audit log, US-067 reservas stock, US-068 refactor Hexagonal).
- **Replan de sprints:** capacity bruta 60h documentada, guia de planning poker, pools MoSCoW.

### Ola 2 — Reclasificacion + coherencia (6 commits granulares)

Tras auditoria triple (clasificacion, formato As-A, coherencia profunda):

1. **Glosario de tipos al inicio.** Define `HU-` (Historia de Usuario), `TT-` (Tarea Tecnica), `EN-` (Enabler/Infraestructura), `MX-` (Mixto), `SP-` (Spike). Reglas de planeacion y estimacion.

2. **Reclasificacion completa.** 31 items mal rotulados como `US-XXX` se renombraron al prefijo correcto:
   - **17 TT-** (tareas tecnicas): TT-002, TT-004, TT-005, TT-009, TT-010, TT-024, TT-025, TT-029, TT-043, TT-044, TT-045, TT-047, TT-048, TT-050, TT-066, TT-067, TT-068.
   - **12 EN-** (enablers): EN-001, EN-003, EN-006, EN-055..060, EN-062..064.
   - **1 MX-**: MX-051 Habeas Data.
   - **34 HU-** reales mantienen el formato "Como X, quiero Y, para Z".

3. **Particion de items grandes.** TT-068 (refactor 7 contextos, probable >21 pts) partido en TT-068a/b/c. TT-005 (mapeo JPA, probable >13 pts) partido en TT-005a/b/c. Cada sub-item con dependencias explicitas.

4. **Refinamiento de coherencia.** HU-014 y HU-036 con beneficio fortalecido. TT-024 renombrado a "Validacion al agregar al carrito" (era ambiguo). TT-067 a "Reserva pesimista durante checkout (timeout 10min)". HU-037 a "Soft-delete de Usuario preservando historial".

5. **Dependencias explicitas.** TT-029 (descontar stock) ahora declara `Depende de TT-067`. HU-030 (cancelar checkout) declara liberacion automatica de reservas asociadas.

6. **Epica 14 — Roadmap Fase 2.** 8 items identificados como fuera de alcance MVP pero documentados como roadmap futuro: HU-069 (actualizar stock manual), HU-070 (reporte por categoria), HU-071 (reporte por empleado), HU-072 (factura PDF), TT-073 (auditoria de consultas), HU-074 (responsive), HU-075 (vaciar carrito 1-clic), HU-076 (busqueda combinada). Todos `Could have` con tag `[Fase 2]`.

7. **Sprint 1 ajustado.** 4 bloqueantes absolutos (no DTOs como antes): EN-001 (estructura paquetes), EN-058 (Flyway), TT-005a (BigDecimal), TT-068a (estructura hexagonal + Identidad). TT-002 y demas pasan a "fundacionales blandos" Sprint 2.

## Archivos modificados

- `docs/BACKLOG.md` (unico archivo en este PR).

## Historia de commits (limpia tras `git reset` + `git push --force-with-lease`)

```
de69c2d docs(backlog): Sprint 1 con 4 bloqueantes absolutos + epica 14 en resumen + v1.2
cac198e docs(backlog): agregar epica 14 Roadmap Fase 2 con 8 items diferidos
10ff02f docs(backlog): refinar HU-014/036 y clarificar TT-024/037/067 con dependencias
349194c docs(backlog): partir TT-068 y TT-005 en sub-items por tamano
f4ecccb docs(backlog): reclasificar 31 items con prefijos HU/TT/EN/MX (renombre completo)
e54b90f docs(backlog): agregar glosario de tipos HU/TT/EN/MX/SP en convenciones
8a057a2 docs(backlog): aplicar revamp completo Ola 1 con hallazgos PO y epicas 12-13
```

## Test plan

- [ ] `grep -c "^#### HU-" docs/BACKLOG.md` >= 34 (HUs reales)
- [ ] `grep -c "^#### TT-" docs/BACKLOG.md` >= 17 (mas sub-items 005a/b/c, 068a/b/c, 073)
- [ ] `grep -c "^#### EN-" docs/BACKLOG.md` >= 12
- [ ] `grep -c "^#### MX-" docs/BACKLOG.md` >= 1
- [ ] `grep "^#### US-" docs/BACKLOG.md` retorna vacio
- [ ] Glosario de tipos visible en seccion "Convenciones del backlog"
- [ ] Sprint 1 contiene EN-001, EN-058, TT-005a, TT-068a (no TT-002)
- [ ] Brian (PO) hace walk-through y confirma:
  - [ ] Glosario claro y util
  - [ ] Sprint 1 con bloqueantes correctos
  - [ ] Planning poker es ejecutable manualmente
  - [ ] Items Fase 2 quedan visibles pero fuera del MVP

## Plan de rollback

`git reset --hard chore/backlog-revisions.backup` (rama backup local) y `git push --force-with-lease`. Backup conserva el estado pre-reset.

## Sincronizacion con PR #28

Diferida hasta despues del merge de este PR. PR #28 (revamp arquitectonico) conserva US-XXX legacy. Tras merge, se abrira PR pequeño `docs/sync-nomenclatura-hu-tt-en` que actualiza REQUIREMENTS.md, DESIGN.md, DOMAIN.md, ADRs y demas docs con la nueva nomenclatura.

## Proximos pasos post-merge

1. Refinement con PO sobre items marcados para discusion (RF-007, RF-016, RF-022, RF-070, prioridades de HU-031/TT-044/EN-059).
2. Sesion planning poker conjunta para estimar TODOS los items (HU+TT+EN+MX).
3. Sprint 1 arranca con los 4 bloqueantes. Velocity real al cierre define capacity de Sprint 2.

Refs: #15
